### PR TITLE
Improve typeshed type processing

### DIFF
--- a/pyanalyze/name_check_visitor.py
+++ b/pyanalyze/name_check_visitor.py
@@ -144,12 +144,6 @@ _DEFAULT_FUNCTION_INFO = FunctionInfo(AsyncFunctionKind.normal, False, False, Fa
 _BOOL_DUNDER = "__bool__" if six.PY3 else "__nonzero__"
 
 
-if asyncio is None:
-    _future_value = NO_RETURN_VALUE
-else:
-    _future_value = TypedValue(asyncio.Future)
-
-
 class ClassAttributeChecker(object):
     """Helper class to keep track of attributes that are read and set on instances."""
 
@@ -2767,9 +2761,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
         # If the value is an awaitable or is assignable to asyncio.Future, show
         # an error about a missing await.
         elif isinstance(value, AwaitableIncompleteValue) or (
-            value is not UNRESOLVED_VALUE
-            and value is not NO_RETURN_VALUE
-            and _future_value.is_value_compatible(value)
+            asyncio is not None and value.is_type(asyncio.Future)
         ):
             if self.is_async_def:
                 new_node = ast.Expr(value=ast.Await(value=node.value))

--- a/pyanalyze/name_check_visitor.py
+++ b/pyanalyze/name_check_visitor.py
@@ -97,22 +97,29 @@ from pyanalyze.value import (
 )
 
 OPERATION_TO_DESCRIPTION_AND_METHOD = {
-    ast.Add: ("addition", "__add__", "__radd__"),
-    ast.Sub: ("subtraction", "__sub__", "__rsub__"),
-    ast.Mult: ("multiplication", "__mul__", "__rmul__"),
-    ast.Div: ("division", "__div__", "__rdiv__"),
-    ast.Mod: ("modulo", "__mod__", "__rmod__"),
-    ast.Pow: ("exponentiation", "__pow__", "__rpow__"),
-    ast.LShift: ("left-shifting", "__lshift__", "__rlshift__"),
-    ast.RShift: ("right-shifting", "__rshift__", "__rrshift__"),
-    ast.BitOr: ("bitwise OR", "__or__", "__ror__"),
-    ast.BitXor: ("bitwise XOR", "__xor__", "__rxor__"),
-    ast.BitAnd: ("bitwise AND", "__and__", "__rand__"),
-    ast.FloorDiv: ("floor division", "__floordiv__", "__rfloordiv__"),
-    ast.Invert: ("inversion", "__invert__", None),
-    ast.UAdd: ("unary positive", "__pos__", None),
-    ast.USub: ("unary negation", "__neg__", None),
+    ast.Add: ("addition", "__add__", "__iadd__", "__radd__"),
+    ast.Sub: ("subtraction", "__sub__", "__isub__", "__rsub__"),
+    ast.Mult: ("multiplication", "__mul__", "__imul__", "__rmul__"),
+    ast.Div: ("division", "__div__", "__idiv__", "__rdiv__"),
+    ast.Mod: ("modulo", "__mod__", "__imod__", "__rmod__"),
+    ast.Pow: ("exponentiation", "__pow__", "__ipow__", "__rpow__"),
+    ast.LShift: ("left-shifting", "__lshift__", "__ilshift__", "__rlshift__"),
+    ast.RShift: ("right-shifting", "__rshift__", "__irshift__", "__rrshift__"),
+    ast.BitOr: ("bitwise OR", "__or__", "__ior__", "__ror__"),
+    ast.BitXor: ("bitwise XOR", "__xor__", "__ixor__", "__rxor__"),
+    ast.BitAnd: ("bitwise AND", "__and__", "__iand__", "__rand__"),
+    ast.FloorDiv: ("floor division", "__floordiv__", "__ifloordiv__", "__rfloordiv__"),
+    ast.Invert: ("inversion", "__invert__", None, None),
+    ast.UAdd: ("unary positive", "__pos__", None, None),
+    ast.USub: ("unary negation", "__neg__", None, None),
 }
+if hasattr(ast, "MatMult"):
+    OPERATION_TO_DESCRIPTION_AND_METHOD[ast.MatMult] = (
+        "matrix multiplication",
+        "__matmul__",
+        "__imatmul__",
+        "__rmatmul__",
+    )
 
 
 # these don't appear to be in the standard types module
@@ -2126,7 +2133,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
             return val, constraint.invert()
         else:
             operand = self.visit(node.operand)
-            _, method, _ = OPERATION_TO_DESCRIPTION_AND_METHOD[type(node.op)]
+            _, method, _, _ = OPERATION_TO_DESCRIPTION_AND_METHOD[type(node.op)]
             val = self._check_dunder_call(node, operand, method, [], allow_call=True)
             return val, NULL_CONSTRAINT
 
@@ -2138,7 +2145,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
         )
 
     def _visit_binop_internal(
-        self, left_node, left, op, right_node, right, source_node
+        self, left_node, left, op, right_node, right, source_node, is_inplace=False
     ):
         # check for some py3 deprecations
         if (
@@ -2198,14 +2205,27 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
         if isinstance(op, ast.Div):
             if six.PY3 or "division" in self.future_imports:
                 method = "__truediv__"
+                imethod = "__itruediv__"
                 rmethod = "__rtruediv__"
             else:
                 method = "__div__"
+                imethod = "__idiv__"
                 rmethod = "__rdiv__"
             description = "division"
         else:
-            description, method, rmethod = OPERATION_TO_DESCRIPTION_AND_METHOD[type(op)]
+            description, method, imethod, rmethod = OPERATION_TO_DESCRIPTION_AND_METHOD[
+                type(op)
+            ]
         allow_call = method not in self.config.DISALLOW_CALLS_TO_DUNDERS
+
+        if is_inplace:
+            with self.catch_errors() as inplace_errors:
+                inplace_result = self._check_dunder_call(
+                    source_node, left, imethod, [right], allow_call=allow_call
+                )
+            if not inplace_errors:
+                return inplace_result
+
         with self.catch_errors() as left_errors:
             left_result = self._check_dunder_call(
                 source_node, left, method, [right], allow_call=allow_call
@@ -2817,7 +2837,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
             lhs = UNRESOLVED_VALUE
 
         value = self._visit_binop_internal(
-            node.target, lhs, node.op, node.value, rhs, node
+            node.target, lhs, node.op, node.value, rhs, node, is_inplace=True
         )
 
         with qcore.override(

--- a/pyanalyze/test_arg_spec.py
+++ b/pyanalyze/test_arg_spec.py
@@ -813,7 +813,6 @@ def g():
         )
 
     @skip_before((3, 6))
-    @only_before((3, 9))
     def test_coroutine_from_typeshed(self):
         self.assert_passes(
             """
@@ -822,9 +821,7 @@ from asyncio.streams import open_connection, StreamReader, StreamWriter
 
 async def capybara():
     # annotated as def ... -> Future in typeshed
-    # This doesn't work in 3.9 because we become smart enough to understand that
-    # it returns a Future, but not smart enough to await a Future.
-    assert_is_value(asyncio.sleep(3), AwaitableIncompleteValue(UNRESOLVED_VALUE))
+    assert_is_value(asyncio.sleep(3), GenericValue(asyncio.Future, [UNRESOLVED_VALUE]))
     return 42
 """
         )

--- a/pyanalyze/test_name_check_visitor.py
+++ b/pyanalyze/test_name_check_visitor.py
@@ -469,6 +469,21 @@ def capybara():
             assert_is_value(2 + 3, KnownValue(5))
 
     @assert_passes()
+    def test_inplace_binop(self):
+        class Capybara:
+            def __add__(self, x: int) -> str:
+                return ""
+
+            def __iadd__(self, x: str) -> int:
+                return 0
+
+        def tucotuco():
+            x = Capybara()
+            assert_is_value(x + 1, TypedValue(str))
+            x += "a"
+            assert_is_value(x, TypedValue(int))
+
+    @assert_passes()
     def test_global_sets_value(self):
         capybara = None
 

--- a/pyanalyze/test_name_check_visitor.py
+++ b/pyanalyze/test_name_check_visitor.py
@@ -468,20 +468,24 @@ def capybara():
         def tucotuco():
             assert_is_value(2 + 3, KnownValue(5))
 
-    @assert_passes()
+    @skip_before((3, 0))
     def test_inplace_binop(self):
-        class Capybara:
-            def __add__(self, x: int) -> str:
-                return ""
+        self.assert_passes(
+            """
+class Capybara:
+    def __add__(self, x: int) -> str:
+        return ""
 
-            def __iadd__(self, x: str) -> int:
-                return 0
+    def __iadd__(self, x: str) -> int:
+        return 0
 
-        def tucotuco():
-            x = Capybara()
-            assert_is_value(x + 1, TypedValue(str))
-            x += "a"
-            assert_is_value(x, TypedValue(int))
+def tucotuco():
+    x = Capybara()
+    assert_is_value(x + 1, TypedValue(str))
+    x += "a"
+    assert_is_value(x, TypedValue(int))
+"""
+        )
 
     @assert_passes()
     def test_global_sets_value(self):

--- a/pyanalyze/test_name_check_visitor.py
+++ b/pyanalyze/test_name_check_visitor.py
@@ -756,6 +756,7 @@ class TestAttributes(TestNameCheckVisitorBase):
                 ),
             )
 
+    @skip_before((3, 0))
     @assert_passes()
     def test_attrs(self):
         import attr


### PR DESCRIPTION
By reusing `type_from_ast()` from `pyanalyze.annotations`, instead of rolling our own.

Also make a few fixes to deal with the fallout from this change:
- Make the missing await detector also detect `asyncio.Future`
- Support in-place methods properly
- Hardcode a more forgiving type for `typing.NewType`