### PR TITLE
Make UnboundMethodValue store the value of its self object

### DIFF
--- a/pyanalyze/annotations.py
+++ b/pyanalyze/annotations.py
@@ -281,6 +281,10 @@ def _type_from_value(value: Value, ctx: Context) -> Value:
             return TypedValue(type)
         elif typing_inspect.is_generic_type(root):
             origin = typing_inspect.get_origin(root)
+            if origin is None:
+                # On Python 3.9 at least, get_origin() of a class that inherits
+                # from Generic[T] is None.
+                origin = root
             if getattr(origin, "__extra__", None) is not None:
                 origin = origin.__extra__
             return GenericValue(

--- a/pyanalyze/asynq_checker.py
+++ b/pyanalyze/asynq_checker.py
@@ -81,7 +81,7 @@ class AsynqChecker:
         elif (
             isinstance(value, UnboundMethodValue)
             and value.secondary_attr_name is None
-            and hasattr(value.typ, value.attr_name + "_async")
+            and hasattr(value.typ.get_type(), value.attr_name + "_async")
         ):
             if isinstance(node.func, ast.Attribute):
                 func_node = ast.Attribute(
@@ -94,7 +94,7 @@ class AsynqChecker:
             self._show_impure_async_error(
                 node,
                 replacement_call="%s.%s_async"
-                % (_stringify_obj(value.typ), value.attr_name),
+                % (_stringify_obj(value.typ.get_type()), value.attr_name),
                 replacement_node=replacement_node,
             )
 
@@ -125,7 +125,7 @@ class AsynqChecker:
                     getattr(root_value.typ, async_name)
                 ):
                     replacement_call = _stringify_async_fn(
-                        UnboundMethodValue(async_name, root_value.typ, "asynq")
+                        UnboundMethodValue(async_name, root_value, "asynq")
                     )
                     method_node = ast.Attribute(value=node.value, attr=async_name)
                     func_node = ast.Attribute(value=method_node, attr="asynq")
@@ -218,7 +218,7 @@ def _stringify_async_fn(value: Value) -> str:
     if isinstance(value, KnownValue):
         return _stringify_obj(value.val)
     elif isinstance(value, UnboundMethodValue):
-        ret = "%s.%s" % (_stringify_obj(value.typ), value.attr_name)
+        ret = "%s.%s" % (_stringify_obj(value.typ.get_type()), value.attr_name)
         if value.secondary_attr_name is not None:
             ret += ".%s" % value.secondary_attr_name
         return ret

--- a/pyanalyze/attributes.py
+++ b/pyanalyze/attributes.py
@@ -148,7 +148,7 @@ def _unwrap_value_from_typed(result: Value, typ: type, ctx: AttrContext) -> Valu
     elif qcore.inspection.is_classmethod(cls_val):
         return KnownValue(cls_val)
     elif inspect.ismethod(cls_val):
-        return UnboundMethodValue(ctx.attr, typ)
+        return UnboundMethodValue(ctx.attr, ctx.root_value)
     elif inspect.isfunction(cls_val):
         # either a staticmethod or an unbound method
         try:
@@ -156,24 +156,24 @@ def _unwrap_value_from_typed(result: Value, typ: type, ctx: AttrContext) -> Valu
         except AttributeError:
             # probably a super call; assume unbound method
             if ctx.attr != "__new__":
-                return UnboundMethodValue(ctx.attr, typ)
+                return UnboundMethodValue(ctx.attr, ctx.root_value)
             else:
                 # __new__ is implicitly a staticmethod
                 return KnownValue(cls_val)
         if isinstance(descriptor, staticmethod) or ctx.attr == "__new__":
             return KnownValue(cls_val)
         else:
-            return UnboundMethodValue(ctx.attr, typ)
+            return UnboundMethodValue(ctx.attr, ctx.root_value)
     elif isinstance(cls_val, (MethodDescriptorType, SlotWrapperType)):
         # built-in method; e.g. scope_lib.tests.SimpleDatabox.get
-        return UnboundMethodValue(ctx.attr, typ)
+        return UnboundMethodValue(ctx.attr, ctx.root_value)
     elif (
         _static_hasattr(cls_val, "decorator")
         and _static_hasattr(cls_val, "instance")
         and not isinstance(cls_val.instance, type)
     ):
         # non-static method
-        return UnboundMethodValue(ctx.attr, typ)
+        return UnboundMethodValue(ctx.attr, ctx.root_value)
     elif asynq.is_async_fn(cls_val):
         # static or class method
         return KnownValue(cls_val)

--- a/pyanalyze/name_check_visitor.py
+++ b/pyanalyze/name_check_visitor.py
@@ -3279,7 +3279,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
 
         else:
             if isinstance(callee_wrapped, UnboundMethodValue):
-                args = [TypedValue(callee_wrapped.typ)] + args
+                args = [callee_wrapped.typ] + args
 
             if self._is_checking():
                 (

--- a/pyanalyze/name_check_visitor.py
+++ b/pyanalyze/name_check_visitor.py
@@ -3339,7 +3339,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
         elif isinstance(
             callee_wrapped, UnboundMethodValue
         ) and callee_wrapped.secondary_attr_name in ("async", "asynq"):
-            async_fn = getattr(callee_wrapped.typ, callee_wrapped.attr_name)
+            async_fn = callee_wrapped.get_method()
             return (
                 AsyncTaskIncompleteValue(_get_task_cls(async_fn), return_value),
                 constraint,

--- a/pyanalyze/test_arg_spec.py
+++ b/pyanalyze/test_arg_spec.py
@@ -813,7 +813,7 @@ class TestTypeshedClient(TestNameCheckVisitorBase):
 class TestTypeVar(TestNameCheckVisitorBase):
     @assert_passes()
     def test_simple(self):
-        from typing import TypeVar, List
+        from typing import TypeVar, List, Generic
 
         T = TypeVar("T")
 
@@ -825,7 +825,11 @@ class TestTypeVar(TestNameCheckVisitorBase):
                 return elt
             assert False
 
-        def capybara(x: str, xs: List[int]) -> None:
+        class GenCls(Generic[T]):
+            def get_one(self: "GenCls[T]") -> T:
+                raise NotImplementedError
+
+        def capybara(x: str, xs: List[int], gen: GenCls[int]) -> None:
             assert_is_value(id(3), KnownValue(3))
             assert_is_value(id(x), TypedValue(str))
             assert_is_value(get_one(xs), TypedValue(int))
@@ -833,3 +837,5 @@ class TestTypeVar(TestNameCheckVisitorBase):
             # This one doesn't work yet because we don't know how to go from
             # KnownValue([3]) to a GenericValue of some sort.
             # assert_is_value(get_one([3]), KnownValue(3))
+
+            assert_is_value(gen.get_one(), TypedValue(int))

--- a/pyanalyze/test_asynq_checker.py
+++ b/pyanalyze/test_asynq_checker.py
@@ -16,7 +16,7 @@ from .tests import (
     Subclass,
     ASYNQ_METHOD_NAME,
 )
-from .value import KnownValue, UnboundMethodValue
+from .value import KnownValue, UnboundMethodValue, TypedValue
 from .test_name_check_visitor import TestNameCheckVisitorBase
 from .test_node_visitor import assert_fails, assert_passes
 
@@ -402,11 +402,11 @@ def test_stringify_async_fn():
     # UnboundMethodValue
     check(
         "PropertyObject.async_method",
-        UnboundMethodValue("async_method", PropertyObject),
+        UnboundMethodValue("async_method", TypedValue(PropertyObject)),
     )
     check(
         "PropertyObject.async_method.asynq",
-        UnboundMethodValue("async_method", PropertyObject, "asynq"),
+        UnboundMethodValue("async_method", TypedValue(PropertyObject), "asynq"),
     )
 
     check(
@@ -415,7 +415,7 @@ def test_stringify_async_fn():
     assert_eq(
         "super(pyanalyze.tests.Subclass, self).async_method",
         _stringify_async_fn(
-            UnboundMethodValue("async_method", super(Subclass, Subclass))
+            UnboundMethodValue("async_method", TypedValue(super(Subclass, Subclass)))
         ),
     )
 
@@ -435,9 +435,11 @@ def test_is_impure_async_fn():
     assert not is_impure_async_fn(KnownValue(PropertyObject(1).async_method.asynq))
 
     # UnboundMethodValue
-    assert is_impure_async_fn(UnboundMethodValue("async_method", PropertyObject))
+    assert is_impure_async_fn(
+        UnboundMethodValue("async_method", TypedValue(PropertyObject))
+    )
     assert not is_impure_async_fn(
-        UnboundMethodValue("async_method", PropertyObject, "asynq")
+        UnboundMethodValue("async_method", TypedValue(PropertyObject), "asynq")
     )
 
 
@@ -456,5 +458,7 @@ def test_get_pure_async_equivalent():
 
     assert_eq(
         "pyanalyze.tests.PropertyObject.async_method.asynq",
-        get_pure_async_equivalent(UnboundMethodValue("async_method", PropertyObject)),
+        get_pure_async_equivalent(
+            UnboundMethodValue("async_method", TypedValue(PropertyObject))
+        ),
     )

--- a/pyanalyze/test_name_check_visitor.py
+++ b/pyanalyze/test_name_check_visitor.py
@@ -1495,20 +1495,26 @@ class TestUnboundMethodValue(TestNameCheckVisitorBase):
         def capybara(oid):
             assert_is_value(
                 PropertyObject(oid).non_async_method,
-                UnboundMethodValue("non_async_method", PropertyObject),
+                UnboundMethodValue("non_async_method", TypedValue(PropertyObject)),
             )
             assert_is_value(
                 PropertyObject(oid).async_method,
-                UnboundMethodValue("async_method", PropertyObject),
+                UnboundMethodValue("async_method", TypedValue(PropertyObject)),
             )
             assert_is_value(
                 ClassWithAsync().get_async,
-                UnboundMethodValue("get_async", ClassWithAsync),
+                UnboundMethodValue("get_async", TypedValue(ClassWithAsync)),
             )
             assert_is_value(
-                ClassWithAsync().get, UnboundMethodValue("get", ClassWithAsync)
+                ClassWithAsync().get,
+                UnboundMethodValue("get", TypedValue(ClassWithAsync)),
             )
-            assert_is_value([oid].append, UnboundMethodValue("append", list))
+            assert_is_value(
+                [oid].append,
+                UnboundMethodValue(
+                    "append", SequenceIncompleteValue(list, [UNRESOLVED_VALUE])
+                ),
+            )
 
     @assert_passes()
     def test_metaclass_super(self):
@@ -1520,7 +1526,7 @@ class TestUnboundMethodValue(TestNameCheckVisitorBase):
                 # assert_is_value(super(Metaclass, self).__init__,
                 #                 UnboundMethodValue('__init__', super(Metaclass, Metaclass)))
                 assert_is_value(
-                    self.__init__, UnboundMethodValue("__init__", Metaclass)
+                    self.__init__, UnboundMethodValue("__init__", TypedValue(Metaclass))
                 )
 
 

--- a/pyanalyze/test_value.py
+++ b/pyanalyze/test_value.py
@@ -33,23 +33,27 @@ def test_known_value():
 
 
 def test_unbound_method_value():
-    val = value.UnboundMethodValue("get_prop_with_get", tests.PropertyObject)
+    val = value.UnboundMethodValue(
+        "get_prop_with_get", value.TypedValue(tests.PropertyObject)
+    )
     assert_eq("<method get_prop_with_get on pyanalyze.tests.PropertyObject>", str(val))
     assert_eq("get_prop_with_get", val.attr_name)
-    assert_is(tests.PropertyObject, val.typ)
+    assert_eq(TypedValue(tests.PropertyObject), val.typ)
     assert_is(None, val.secondary_attr_name)
     assert_eq(tests.PropertyObject.get_prop_with_get, val.get_method())
     assert val.is_type(object)
     assert not val.is_type(str)
 
     val = value.UnboundMethodValue(
-        "get_prop_with_get", tests.PropertyObject, secondary_attr_name="asynq"
+        "get_prop_with_get",
+        value.TypedValue(tests.PropertyObject),
+        secondary_attr_name="asynq",
     )
     assert_eq(
         "<method get_prop_with_get.asynq on pyanalyze.tests.PropertyObject>", str(val)
     )
     assert_eq("get_prop_with_get", val.attr_name)
-    assert_is(tests.PropertyObject, val.typ)
+    assert_eq(TypedValue(tests.PropertyObject), val.typ)
     assert_eq("asynq", val.secondary_attr_name)
     method = val.get_method()
     assert_in(method.__name__, tests.ASYNQ_METHOD_NAMES)

--- a/pyanalyze/value.py
+++ b/pyanalyze/value.py
@@ -241,7 +241,6 @@ class TypedValue(Value):
                 return True
             return are_types_compatible(self.typ, type(val.val))
         elif isinstance(val, TypedValue):
-            print("IIIII", self, val)
             if issubclass(val.typ, self.typ):
                 return True
             return are_types_compatible(self.typ, val.typ)

--- a/pyanalyze/value.py
+++ b/pyanalyze/value.py
@@ -241,6 +241,7 @@ class TypedValue(Value):
                 return True
             return are_types_compatible(self.typ, type(val.val))
         elif isinstance(val, TypedValue):
+            print("IIIII", self, val)
             if issubclass(val.typ, self.typ):
                 return True
             return are_types_compatible(self.typ, val.typ)

--- a/pyanalyze/value.py
+++ b/pyanalyze/value.py
@@ -176,13 +176,14 @@ class UnboundMethodValue(Value):
     """
 
     attr_name: str
-    typ: type
+    typ: Value
     secondary_attr_name: Optional[str] = None
 
     def get_method(self) -> Optional[Any]:
         """Returns the method object for this UnboundMethodValue."""
         try:
-            method = getattr(self.typ, self.attr_name)
+            typ = self.typ.get_type()
+            method = getattr(typ, self.attr_name)
             if self.secondary_attr_name is not None:
                 method = getattr(method, self.secondary_attr_name)
             # don't use unbound methods in py2
@@ -205,7 +206,7 @@ class UnboundMethodValue(Value):
         return "<method %s%s on %s>" % (
             self.attr_name,
             ".%s" % (self.secondary_attr_name,) if self.secondary_attr_name else "",
-            _stringify_type(self.typ),
+            self.typ,
         )
 
 


### PR DESCRIPTION
This lets us correctly handle generic methods with explicit self types, like in the new test case in test_arg_spec. It does not yet handle similar methods without an explicit type; I need to find a way to set a correct type for `self` on those.