### PR TITLE
remove inspect2 dep

### DIFF
--- a/pyanalyze/arg_spec.py
+++ b/pyanalyze/arg_spec.py
@@ -37,7 +37,7 @@ import asynq
 import builtins
 from dataclasses import dataclass, field, InitVar
 from functools import reduce
-import collections
+import collections.abc
 import contextlib
 import qcore
 import inspect
@@ -711,7 +711,7 @@ def _sequence_impl(
         return SequenceIncompleteValue(typ, [key for key, _ in iterable.items])
     elif isinstance(iterable, TypedValue):
         if not iterable.is_type(
-            collections.Iterable
+            collections.abc.Iterable
         ) and not visitor._should_ignore_type(iterable.typ):
             visitor.show_error(
                 node,

--- a/pyanalyze/name_check_visitor.py
+++ b/pyanalyze/name_check_visitor.py
@@ -10,7 +10,7 @@ import ast
 from ast_decompiler import decompile
 import asyncio
 import builtins
-import collections
+import collections.abc
 import contextlib
 from dataclasses import dataclass
 from functools import reduce
@@ -2566,7 +2566,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
             )
         elif isinstance(iterated, TypedValue):
             if not issubclass(
-                iterated.typ, collections.Iterable
+                iterated.typ, collections.abc.Iterable
             ) and not self._should_ignore_type(iterated.typ):
                 self._show_error_if_checking(
                     node,

--- a/pyanalyze/name_check_visitor.py
+++ b/pyanalyze/name_check_visitor.py
@@ -16,7 +16,6 @@ from dataclasses import dataclass
 from functools import reduce
 import imp
 import inspect
-import inspect2
 from itertools import chain
 import logging
 import os.path
@@ -3630,7 +3629,7 @@ def _safe_getattr(value, attr, default):
 
 def _is_coroutine_function(obj):
     try:
-        return inspect2.iscoroutinefunction(obj)
+        return inspect.iscoroutinefunction(obj)
     except AttributeError:
         # This can happen to cached classmethods.
         return False

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,6 @@ if __name__ == "__main__":
         install_requires=[
             "attrs",
             "asynq",
-            "inspect2",
             "dataclasses; python_version < '3.7'",
             "nose",
             "qcore>=0.5.1",


### PR DESCRIPTION
Was only used for inspect2.iscoroutinefunction, but that's been
in the stdlib since 3.5, so we don't need the backport.

https://docs.python.org/3/library/inspect.html#inspect.iscoroutinefunction