### PR TITLE
Fix for assigning a BytesIO to an IO object

### DIFF
--- a/pyanalyze/arg_spec.py
+++ b/pyanalyze/arg_spec.py
@@ -680,6 +680,11 @@ class TypeshedFinder(object):
             module = obj.__module__
             if module is None:
                 module = "builtins"
+            # Objects like io.BytesIO are technically in the _io module,
+            # but typeshed puts them in io, which at runtime just re-exports
+            # them.
+            if module == "_io":
+                module = "io"
             fq_name = ".".join([module, obj.__qualname__])
             return _TYPING_ALIASES.get(fq_name, fq_name)
         except (AttributeError, TypeError):

--- a/pyanalyze/test_arg_spec.py
+++ b/pyanalyze/test_arg_spec.py
@@ -11,7 +11,9 @@ from collections.abc import (
     Set,
 )
 import contextlib
+import io
 import time
+import typing
 from typing import Generic, TypeVar
 
 from .test_config import TestConfig
@@ -432,4 +434,18 @@ class TestGetGenericBases:
                 collections.abc.Container: [int_tv],
             },
             self.get_generic_bases(dict, [int_tv, str_tv]),
+        )
+
+    def test_io(self):
+        assert_eq(
+            {
+                io.BytesIO: [],
+                io.BufferedIOBase: [],
+                io.IOBase: [],
+                typing.BinaryIO: [],
+                typing.IO: [TypedValue(bytes)],
+                collections.abc.Iterator: [TypedValue(bytes)],
+                collections.abc.Iterable: [TypedValue(bytes)],
+            },
+            self.get_generic_bases(io.BytesIO, []),
         )

--- a/pyanalyze/test_value.py
+++ b/pyanalyze/test_value.py
@@ -1,6 +1,8 @@
 import collections.abc
+import io
 from qcore.asserts import assert_eq, assert_in, assert_is, assert_is_not
 from typing import NewType, Sequence, Dict
+import typing
 import types
 from unittest import mock
 
@@ -346,3 +348,9 @@ def test_new_type_value():
     # This should eventually return False
     assert_can_assign(nt1_val, TypedValue(int))
     assert_can_assign(TypedValue(int), nt1_val)
+
+
+def test_io():
+    assert_can_assign(
+        GenericValue(typing.IO, [UNRESOLVED_VALUE]), TypedValue(io.BytesIO)
+    )

--- a/pyanalyze/value.py
+++ b/pyanalyze/value.py
@@ -405,9 +405,10 @@ class GenericValue(TypedValue):
             # runtime isinstance() may disagree.
             if generic_args is None or len(self.args) != len(generic_args):
                 return super().can_assign(other, ctx)
-            tv_maps = [super().can_assign(other, ctx)]
-            for arg1, arg2 in zip(self.args, generic_args):
-                tv_maps.append(arg1.can_assign(arg2, ctx))
+            tv_maps = [
+                arg1.can_assign(arg2, ctx)
+                for arg1, arg2 in zip(self.args, generic_args)
+            ]
             return unify_typevar_maps(tv_maps)
         return super().can_assign(other, ctx)
 

--- a/pyanalyze/value.py
+++ b/pyanalyze/value.py
@@ -318,6 +318,24 @@ class TypedValue(Value):
             return unify_typevar_maps(tv_maps)
         return None
 
+    def get_generic_args_for_type(
+        self, typ: Union[type, super], ctx: CanAssignContext
+    ) -> Optional[List[Value]]:
+        if isinstance(self, GenericValue):
+            args = self.args
+        else:
+            args = ()
+        generic_bases = ctx.get_generic_bases(self.typ, args)
+        return generic_bases.get(typ)
+
+    def get_generic_arg_for_type(
+        self, typ: Union[type, super], ctx: CanAssignContext, index: int
+    ) -> Value:
+        args = self.get_generic_args_for_type(typ, ctx)
+        if args and index < len(args):
+            return args[index]
+        return UNRESOLVED_VALUE
+
     def is_type(self, typ: type) -> bool:
         return self.type_object.is_assignable_to_type(typ)
 
@@ -382,18 +400,10 @@ class GenericValue(TypedValue):
 
     def can_assign(self, other: Value, ctx: CanAssignContext) -> Optional[TypeVarMap]:
         if isinstance(other, TypedValue) and isinstance(other.typ, type):
-            if isinstance(other, GenericValue):
-                args = other.args
-            else:
-                args = ()
-            generic_bases = ctx.get_generic_bases(other.typ, args)
-            try:
-                generic_args = generic_bases[self.typ]
-            except KeyError:
-                # If we don't think it's a generic base, try super;
-                # runtime isinstance() may disagree.
-                return super().can_assign(other, ctx)
-            if len(self.args) != len(generic_args):
+            generic_args = other.get_generic_args_for_type(self.typ, ctx)
+            # If we don't think it's a generic base, try super;
+            # runtime isinstance() may disagree.
+            if generic_args is None or len(self.args) != len(generic_args):
                 return super().can_assign(other, ctx)
             tv_maps = [super().can_assign(other, ctx)]
             for arg1, arg2 in zip(self.args, generic_args):


### PR DESCRIPTION
pyanalyze didn't allow you to pass a `BytesIO` object to an argument typed as `typing.IO` because of the vagaries of typeshed file structure and because of an overly strict check in `GenericValue.can_assign`.