### PR TITLE
Add new Signature object wrapping inspect.Signature

### DIFF
--- a/pyanalyze/name_check_visitor.py
+++ b/pyanalyze/name_check_visitor.py
@@ -78,8 +78,8 @@ from pyanalyze.signature import (
     MaybeSignature,
     MaybeArgspec,
     BoundMethodSignature,
-    BoundMethodArgSpecWrapper,
     Signature,
+    make_bound_method,
 )
 from pyanalyze.asynq_checker import AsyncFunctionKind, AsynqChecker, FunctionInfo
 from pyanalyze.yield_checker import YieldChecker
@@ -3445,11 +3445,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor, CanAssignContext):
                 return None
             call_fn = typ.__call__
             argspec = self._get_argspec(call_fn, node, name=name)
-            if argspec is None:
-                return None
-            if isinstance(argspec, Signature):
-                return BoundMethodSignature(argspec, callee_wrapped)
-            return BoundMethodArgSpecWrapper(argspec, callee_wrapped)
+            return make_bound_method(argspec, callee_wrapped)
         return None
 
     def _get_argspec(

--- a/pyanalyze/node_visitor.py
+++ b/pyanalyze/node_visitor.py
@@ -548,7 +548,7 @@ class BaseNodeVisitor(ast.NodeVisitor):
                 # four columns for the line number
                 # app/view/question/__init__.py is 6900 lines
                 context += "%4d: %s" % (i, lines[i - 1])
-                if i == lineno:
+                if i == lineno and col_offset is not None:
                     # caret to indicate the position of the error
                     context += " " * (6 + col_offset) + "^\n"
             message += context

--- a/pyanalyze/signature.py
+++ b/pyanalyze/signature.py
@@ -395,6 +395,7 @@ class PropertyArgSpec:
         return self.return_value is not UNRESOLVED_VALUE
 
 
+# TODO replace this with Signature
 @dataclass
 class ExtendedArgSpec:
     """A richer version of the standard inspect.ArgSpec object.

--- a/pyanalyze/test_arg_spec.py
+++ b/pyanalyze/test_arg_spec.py
@@ -23,14 +23,8 @@ from .test_name_check_visitor import (
     ConfiguredNameCheckVisitor,
 )
 from .test_node_visitor import assert_passes
-from .arg_spec import (
-    ArgSpecCache,
-    BoundMethodArgSpecWrapper,
-    ExtendedArgSpec,
-    Parameter,
-    TypeshedFinder,
-    is_dot_asynq_function,
-)
+from .signature import BoundMethodArgSpecWrapper, ExtendedArgSpec, Parameter
+from .arg_spec import ArgSpecCache, TypeshedFinder, is_dot_asynq_function
 from .tests import l0cached_async_fn
 from .value import (
     KnownValue,

--- a/pyanalyze/test_arg_spec.py
+++ b/pyanalyze/test_arg_spec.py
@@ -229,7 +229,7 @@ class TestCoroutines(TestNameCheckVisitorBase):
         async def capybara():
             # annotated as def ... -> Future in typeshed
             assert_is_value(
-                asyncio.sleep(3), GenericValue(asyncio.Future, [KnownValue(None)])
+                asyncio.sleep(3), GenericValue(asyncio.Future, [UNRESOLVED_VALUE])
             )
             return 42
 

--- a/pyanalyze/test_implementation.py
+++ b/pyanalyze/test_implementation.py
@@ -360,6 +360,13 @@ class TestGenericMutators(TestNameCheckVisitorBase):
                 lst, SequenceIncompleteValue(list, [KnownValue("x"), KnownValue(3)])
             )
 
+    @assert_fails(ErrorCode.incompatible_call)
+    def test_list_append_pos_only(self):
+        from typing import List
+
+        def capybara(lst: List[int]) -> None:
+            lst.append(object=42)
+
     @assert_fails(ErrorCode.incompatible_argument)
     def test_list_append_wrong_type(self):
         from typing import List


### PR DESCRIPTION
For now, just use it for hardcoded signatures in implementation.py. The only concrete difference so far should be that positional-only arguments are handled correctly.

First step for #51