### PR TITLE
clean up ExtendedArgSpec

### DIFF
--- a/pyanalyze/annotations.py
+++ b/pyanalyze/annotations.py
@@ -260,7 +260,7 @@ def _type_from_value(value: Value, ctx: Context) -> Value:
             return unite_values(*[_type_from_value(elt, ctx) for elt in value.members])
         elif is_typing_name(root, "Literal"):
             if all(isinstance(elt, KnownValue) for elt in value.members):
-                return unite_values(value.members)
+                return unite_values(*value.members)
             else:
                 ctx.show_error(
                     "Arguments to Literal[] must be literals, not %s" % (value.members,)

--- a/pyanalyze/signature.py
+++ b/pyanalyze/signature.py
@@ -7,7 +7,6 @@ Wrappers around Signature objects.
 from .error_code import ErrorCode
 from .stacked_scopes import NULL_CONSTRAINT, AbstractConstraint
 from .value import (
-    TypedValue,
     KnownValue,
     SequenceIncompleteValue,
     DictIncompleteValue,
@@ -19,15 +18,12 @@ from .value import (
 )
 
 import ast
-import builtins
-from dataclasses import dataclass, field, InitVar
+from dataclasses import dataclass, field
 import inspect
 import qcore
 import logging
-import re
 from typing import (
     Any,
-    Sequence,
     Iterable,
     Optional,
     ClassVar,
@@ -69,7 +65,6 @@ ImplementationFn = Callable[
 ]
 Logger = Callable[[int, str, object], object]
 EMPTY = inspect.Parameter.empty
-NON_IDENTIFIER_CHARS = re.compile(r"[^a-zA-Z_\d]")
 
 ARGS = qcore.MarkerObject("*args")
 KWARGS = qcore.MarkerObject("**kwargs")
@@ -130,6 +125,7 @@ class Signature:
     signature: inspect.Signature
     implementation: Optional[ImplementationFn] = None
     callable: Optional[object] = None
+    has_return_annotation: bool = True
     logger: Optional[Logger] = field(repr=False, default=None, compare=False)
     typevars_of_params: Dict[str, List["TypeVar"]] = field(
         init=False, default_factory=dict, repr=False, compare=False
@@ -278,24 +274,27 @@ class Signature:
         cls,
         parameters: Iterable[SigParameter],
         return_annotation: Optional[Value] = None,
+        *,
         implementation: Optional[ImplementationFn] = None,
         callable: Optional[object] = None,
+        logger: Optional[Logger] = None,
+        has_return_annotation: bool = True,
     ) -> "Signature":
-        # We can't annotate it as EMPTY because that breaks typechecking
-        # pyanalyze itself.
         if return_annotation is None:
-            return_annotation = EMPTY
+            return_annotation = UNRESOLVED_VALUE
+            has_return_annotation = False
         return cls(
             signature=inspect.Signature(
                 parameters, return_annotation=return_annotation
             ),
             implementation=implementation,
             callable=callable,
+            has_return_annotation=has_return_annotation,
         )
 
     # TODO: do we need these?
     def has_return_value(self) -> bool:
-        return self.signature.return_annotation is not EMPTY
+        return self.has_return_annotation
 
     @property
     def return_value(self):
@@ -322,68 +321,6 @@ class BoundMethodSignature:
         return self.signature.return_value
 
 
-MaybeSignature = Union[None, Signature, BoundMethodSignature]
-
-
-@dataclass
-class Parameter:
-    """Class representing a function parameter.
-
-    default_value is Parameter.no_default_value when there is no default value.
-
-    """
-
-    no_default_value: ClassVar[object] = object()
-
-    name: str
-    default_value: object = no_default_value
-    typ: Optional[Value] = None
-
-    def __post_init__(self) -> None:
-        assert self.typ is None or isinstance(self.typ, Value), repr(self)
-
-
-@dataclass
-class BoundMethodArgSpecWrapper:
-    """Wrapper around ExtendedArgSpec to support bound methods.
-
-    Adds the object that the method is bound to as an argument.
-
-    """
-
-    argspec: "ExtendedArgSpec" = field(init=False)
-    argspec_arg: InitVar[Union["ExtendedArgSpec", "BoundMethodArgSpecWrapper"]]
-    self_value: Value
-
-    def __post_init__(
-        self, argspec_arg: Union["ExtendedArgSpec", "BoundMethodArgSpecWrapper"]
-    ) -> None:
-        if isinstance(argspec_arg, BoundMethodArgSpecWrapper):
-            argspec_arg = argspec_arg.argspec
-        assert isinstance(
-            argspec_arg, ExtendedArgSpec
-        ), f"invalid argspec {argspec_arg!r}"
-        self.argspec = argspec_arg
-
-    def check_call(
-        self,
-        args: Iterable[Value],
-        keywords: Iterable[Tuple[str, Value]],
-        visitor: "NameCheckVisitor",
-        node: ast.AST,
-    ) -> Tuple[Value, AbstractConstraint, AbstractConstraint]:
-        return self.argspec.check_call(
-            [self.self_value, *args], keywords, visitor, node
-        )
-
-    def has_return_value(self) -> bool:
-        return self.argspec.has_return_value()
-
-    @property
-    def return_value(self) -> Value:
-        return self.argspec.return_value
-
-
 @dataclass
 class PropertyArgSpec:
     """Pseudo-argspec for properties."""
@@ -392,11 +329,7 @@ class PropertyArgSpec:
     return_value: Value = UNRESOLVED_VALUE
 
     def check_call(
-        self,
-        args: Iterable[Value],
-        keywords: Iterable[Tuple[str, Value]],
-        visitor: "NameCheckVisitor",
-        node: ast.AST,
+        self, args: Iterable[Argument], visitor: "NameCheckVisitor", node: ast.AST
     ) -> Tuple[Value, AbstractConstraint, AbstractConstraint]:
         raise TypeError("property object is not callable")
 
@@ -404,233 +337,17 @@ class PropertyArgSpec:
         return self.return_value is not UNRESOLVED_VALUE
 
 
-# TODO replace this with Signature
-@dataclass
-class ExtendedArgSpec:
-    """A richer version of the standard inspect.ArgSpec object.
-
-    This stores:
-    - arguments (list of Parameters): all standard arguments taken by the object.
-    - starargs (string or None): name of the *args argument, if present.
-    - kwargs (string or None): name of the **kwargs argument, if present.
-    - kwonly_args (list of Parameters): list of keyword-only arguments taken by the object. Python 2
-      itself does not support this, but some of our objects simulate keyword-only arguments by
-      working with **kwargs.
-    - return_value (Value): what the object returns
-    - name (string): name of the object. This is used only for error output.
-    - implementation (function): a function that implements the object. This gets passed a
-      dictionary corresponding to the function's scope, a NameCheckVisitor object, and the node
-      where the function was called. This can be used for more complicated argument checking and
-      for computing the return value from the arguments.
-
-    """
-
-    _default_value: ClassVar[object] = object()
-    _kwonly_args_name: ClassVar[str] = "__kwargs"
-    _return_key: ClassVar[str] = "%return"
-    _excluded_attributes = {"logger"}
-
-    arguments: Sequence[Parameter]
-    starargs: Optional[str] = None
-    kwargs: Optional[str] = None
-    kwonly_args: Sequence[Parameter] = field(default_factory=list)
-    return_value: Value = UNRESOLVED_VALUE
-    name: Optional[str] = None
-    implementation: Optional[ImplementationFn] = None
-    logger: Optional[Logger] = field(repr=False, default=None, compare=False)
-    params_of_names: Dict[str, Parameter] = field(init=False, repr=False)
-    _has_return_value: bool = field(init=False, repr=False)
-    typevars_of_params: Dict[str, List["TypeVar"]] = field(
-        init=False, default_factory=dict, repr=False
-    )
-    all_typevars: Set["TypeVar"] = field(init=False, default_factory=set, repr=False)
-
-    def __post_init__(self) -> None:
-        self._has_return_value = self.return_value is not UNRESOLVED_VALUE
-        self.params_of_names = {}
-        for param in self.arguments:
-            self.params_of_names[param.name] = param
-        for param in self.kwonly_args:
-            self.params_of_names[param.name] = param
-        if self.starargs is not None:
-            self.params_of_names[self.starargs] = Parameter(
-                self.starargs, typ=TypedValue(tuple)
-            )
-        if self.kwargs is not None:
-            self.params_of_names[self.kwargs] = Parameter(
-                self.kwargs, typ=TypedValue(dict)
-            )
-        for param_name, param in self.params_of_names.items():
-            if param.typ is None:
-                continue
-            typevars = list(extract_typevars(param.typ))
-            if typevars:
-                self.typevars_of_params[param_name] = typevars
-        return_typevars = list(extract_typevars(self.return_value))
-        if return_typevars:
-            self.typevars_of_params[self._return_key] = return_typevars
-        self.all_typevars = {
-            typevar
-            for tv_list in self.typevars_of_params.values()
-            for typevar in tv_list
-        }
-
-    def log(self, level: int, label: str, value: object) -> None:
-        if self.logger is not None:
-            self.logger(level, label, value)
-
-    @qcore.caching.cached_per_instance()
-    def generate_function(self) -> Callable[..., Any]:
-        """Generates a function with this argspec.
-
-        This is done by exec-ing code that corresponds to this argspec. The function will return
-        its locals(). Keyword-only arguments are not checked.
-
-        """
-        argument_strings = []
-        scope: Dict[str, Any] = {
-            "_default_value": self._default_value,
-            # so that we can call locals() from inside the function even if a function argument is
-            # called locals
-            # if you want to call a function argument __builtin__, go do it somewhere else please
-            "__builtin__": builtins,
-        }
-
-        def add_arg(arg):
-            if arg.default_value is Parameter.no_default_value:
-                argument_strings.append(arg.name)
-            else:
-                default_obj_name = "__default_" + arg.name
-                scope[default_obj_name] = KnownValue(arg.default_value)
-                argument_strings.append("%s=%s" % (arg.name, default_obj_name))
-
-        for arg in self.arguments:
-            add_arg(arg)
-
-        if self.starargs is not None:
-            argument_strings.append("*%s" % self.starargs)
-
-        if self.kwonly_args:
-            if self.starargs is None:
-                argument_strings.append("*")
-            for arg in self.kwonly_args:
-                add_arg(arg)
-        if self.kwargs is not None:
-            argument_strings.append("**%s" % self.kwargs)
-
-        if self.name is None:
-            name = "test_function"
-        else:
-            name = str(self.name)
-        # for lambdas name is "<lambda>"
-        name = NON_IDENTIFIER_CHARS.sub("_", name)
-
-        code_str = """
-def %(name)s(%(arguments)s):
-    return __builtin__.locals()
-""" % {
-            "arguments": ", ".join(argument_strings),
-            "name": name,
-        }
-
-        self.log(logging.DEBUG, "Code to execute", code_str)
-        exec (code_str, scope)
-        return scope[name]
-
-    def _check_param_type_compatibility(
-        self,
-        param: Parameter,
-        var_value: Value,
-        visitor: "NameCheckVisitor",
-        node: ast.AST,
-        typevar_map: TypeVarMap,
-    ) -> None:
-        if param.typ is not None and var_value != KnownValue(param.default_value):
-            if typevar_map:
-                param_typ = param.typ.substitute_typevars(typevar_map)
-            else:
-                param_typ = param.typ
-            compatible = param_typ.can_assign(var_value, visitor)
-            if compatible is None:
-                visitor.show_error(
-                    node,
-                    "Incompatible argument type for %s: expected %s but got %s"
-                    % (param.name, param_typ, var_value),
-                    ErrorCode.incompatible_argument,
-                )
-
-    def check_call(
-        self,
-        args: Iterable[Value],
-        keywords: Iterable[Tuple[str, Value]],
-        visitor: "NameCheckVisitor",
-        node: ast.AST,
-    ) -> Tuple[Value, AbstractConstraint, AbstractConstraint]:
-        """Tries to call this object with the given arguments and keyword arguments.
-
-        Raises a TypeError if something goes wrong.
-
-        This is done by calling the function generated by generate_function(), and then examining
-        the local variables to validate types and keyword-only arguments.
-
-        """
-        fn = self.generate_function()
-        try:
-            variables = fn(*args, **dict(keywords))
-        except TypeError as e:
-            visitor.show_error(node, repr(e), ErrorCode.incompatible_call)
-            return UNRESOLVED_VALUE, NULL_CONSTRAINT, NULL_CONSTRAINT
-        return_value = self.return_value
-        typevar_values: Dict[TypeVar, Value] = {}
-        if self.all_typevars:
-            for param_name in self.typevars_of_params:
-                if param_name == self._return_key:
-                    continue
-                var_value = variables[param_name]
-                if var_value is self._default_value:
-                    continue
-                param = self.params_of_names[param_name]
-                if param.typ is None:
-                    continue
-                tv_map = param.typ.can_assign(var_value, visitor)
-                if tv_map:
-                    # For now, the first assignment wins.
-                    for typevar, value in tv_map.items():
-                        typevar_values.setdefault(typevar, value)
-            for typevar in self.all_typevars:
-                typevar_values.setdefault(typevar, UNRESOLVED_VALUE)
-            if self._return_key in self.typevars_of_params:
-                return_value = return_value.substitute_typevars(typevar_values)
-
-        non_param_names = {self.starargs, self.kwargs, self._kwonly_args_name}
-        for name, var_value in variables.items():
-            if var_value is not self._default_value and name not in non_param_names:
-                param = self.params_of_names[name]
-                self._check_param_type_compatibility(
-                    param, var_value, visitor, node, typevar_values
-                )
-
-        if self.implementation is not None:
-            return_value = self.implementation(variables, visitor, node)
-            return clean_up_implementation_fn_return(return_value)
-        else:
-            return return_value, NULL_CONSTRAINT, NULL_CONSTRAINT
-
-    def has_return_value(self) -> bool:
-        # We can't check self.return_value directly here because that may have
-        # been wrapped in an Awaitable.
-        return self._has_return_value
-
-
-MaybeArgspec = Union[None, ExtendedArgSpec, PropertyArgSpec, BoundMethodArgSpecWrapper]
+MaybeSignature = Union[None, Signature, BoundMethodSignature, PropertyArgSpec]
 
 
 def make_bound_method(
-    argspec: Union[MaybeArgspec, MaybeSignature], self_value: Value
-) -> Union[None, BoundMethodSignature, BoundMethodArgSpecWrapper]:
+    argspec: MaybeSignature, self_value: Value
+) -> Optional[BoundMethodSignature]:
     if argspec is None:
         return None
     if isinstance(argspec, Signature):
         return BoundMethodSignature(argspec, self_value)
+    elif isinstance(argspec, BoundMethodSignature):
+        return BoundMethodSignature(argspec.signature, self_value)
     else:
-        return BoundMethodArgSpecWrapper(argspec, self_value)
+        assert False, f"invalid argspec {argspec}"

--- a/pyanalyze/test_arg_spec.py
+++ b/pyanalyze/test_arg_spec.py
@@ -223,11 +223,17 @@ def test_get_argspec():
             ArgSpecCache(config).get_argspec(ClassWithCall.pure_async_classmethod),
         )
 
+        # This behaves differently in 3.9 (decorator) than in 3.6-3.8 (__func__). Not
+        # sure why.
+        if hasattr(ClassWithCall.classmethod_before_async, "decorator"):
+            callable = ClassWithCall.classmethod_before_async.decorator.fn
+        else:
+            callable = ClassWithCall.classmethod_before_async.__func__.fn
+
         assert_eq(
             BoundMethodSignature(
                 Signature.make(
-                    [SigParameter("cls"), SigParameter("ac")],
-                    callable=ClassWithCall.classmethod_before_async.decorator.fn,
+                    [SigParameter("cls"), SigParameter("ac")], callable=callable
                 ),
                 KnownValue(ClassWithCall),
             ),

--- a/pyanalyze/test_config.py
+++ b/pyanalyze/test_config.py
@@ -3,7 +3,7 @@
 Configuration file specific to tests.
 
 """
-from .arg_spec import ExtendedArgSpec, Parameter
+from .arg_spec import Signature, SigParameter
 from .config import Config
 from . import tests
 from . import value
@@ -34,10 +34,16 @@ class TestConfig(Config):
 
     def get_known_argspecs(self, arg_spec_cache):
         return {
-            tests.takes_kwonly_argument: ExtendedArgSpec(
-                [Parameter("a")],
-                name="takes_kwonly_argument",
-                kwonly_args=[Parameter("kwonly_arg", typ=value.TypedValue(bool))],
+            tests.takes_kwonly_argument: Signature.make(
+                [
+                    SigParameter("a"),
+                    SigParameter(
+                        "kwonly_arg",
+                        SigParameter.KEYWORD_ONLY,
+                        annotation=value.TypedValue(bool),
+                    ),
+                ],
+                callable=tests.takes_kwonly_argument,
             )
         }
 


### PR DESCRIPTION
Closes #51 

A user-visible effect is that this makes pyanalyze better at recognizing *args/**kwargs annotations in function definitions. It doesn't help (yet) with *args/**kwargs in calls (#63).