### PR TITLE
Ignore all annotations on @wrapped functions

### DIFF
--- a/pyanalyze/arg_spec.py
+++ b/pyanalyze/arg_spec.py
@@ -446,21 +446,12 @@ class ArgSpecCache:
         try:
             # follow_wrapped=True leads to problems with decorators that
             # mess with the arguments, such as mock.patch.
-            sig = inspect.signature(obj, follow_wrapped=False)
+            return inspect.signature(obj, follow_wrapped=False)
         except (TypeError, ValueError, AttributeError):
             # TypeError if signature() does not support the object, ValueError
             # if it cannot provide a signature, and AttributeError if we're on
             # Python 2.
             return None
-        else:
-            # Signature preserves the return annotation for wrapped functions,
-            # because @functools.wraps copies the __annotations__ of the wrapped function. We
-            # don't want that, because the wrapper may have changed the return type.
-            # This caused problems with @contextlib.contextmanager.
-            if safe_hasattr(obj, "__wrapped__"):
-                return sig.replace(return_annotation=inspect.Signature.empty)
-            else:
-                return sig
 
     def get_generic_bases(
         self, typ: type, generic_args: Sequence[Value] = ()

--- a/pyanalyze/arg_spec.py
+++ b/pyanalyze/arg_spec.py
@@ -185,8 +185,13 @@ class ArgSpecCache:
         if sig is None:
             return None
         func_globals = getattr(function_object, "__globals__", None)
+        # Signature preserves the return annotation for wrapped functions,
+        # because @functools.wraps copies the __annotations__ of the wrapped function. We
+        # don't want that, because the wrapper may have changed the return type.
+        # This caused problems with @contextlib.contextmanager.
+        is_wrapped = safe_hasattr(function_object, "__wrapped__")
 
-        if sig.return_annotation is inspect.Signature.empty:
+        if is_wrapped or sig.return_annotation is inspect.Signature.empty:
             returns = UNRESOLVED_VALUE
             has_return_annotation = False
         else:
@@ -201,7 +206,9 @@ class ArgSpecCache:
                 parameters += kwonly_args
                 kwonly_args = []
             parameters.append(
-                self._make_sig_parameter(parameter, func_globals, function_object, i)
+                self._make_sig_parameter(
+                    parameter, func_globals, function_object, is_wrapped, i
+                )
             )
         parameters += kwonly_args
 
@@ -219,12 +226,16 @@ class ArgSpecCache:
         parameter: inspect.Parameter,
         func_globals: Optional[Mapping[str, object]],
         function_object: Optional[object],
+        is_wrapped: bool,
         index: int,
     ) -> SigParameter:
         """Given an inspect.Parameter, returns a Parameter object."""
-        typ = self._get_type_for_parameter(
-            parameter, func_globals, function_object, index
-        )
+        if is_wrapped:
+            typ = UNRESOLVED_VALUE
+        else:
+            typ = self._get_type_for_parameter(
+                parameter, func_globals, function_object, index
+            )
         if parameter.default is SigParameter.empty:
             default = None
         else:

--- a/pyanalyze/test_arg_spec.py
+++ b/pyanalyze/test_arg_spec.py
@@ -11,6 +11,7 @@ from collections.abc import (
     Set,
 )
 import contextlib
+import functools
 import io
 import itertools
 import time
@@ -85,6 +86,18 @@ def function(capybara, hutia=3, *tucotucos, **proechimys):
 @asynq()
 def async_function(x, y):
     pass
+
+
+def wrapped(args: int, kwargs: str) -> None:
+    pass
+
+
+def decorator(fn):
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        return fn(*args, **kwargs)
+
+    return wrapper
 
 
 def test_get_argspec():
@@ -238,6 +251,33 @@ def test_get_argspec():
                 KnownValue(ClassWithCall),
             ),
             ArgSpecCache(config).get_argspec(ClassWithCall.classmethod_before_async),
+        )
+
+        assert_eq(
+            Signature.make(
+                [
+                    SigParameter("args", annotation=TypedValue(int)),
+                    SigParameter("kwargs", annotation=TypedValue(str)),
+                ],
+                KnownValue(None),
+                callable=wrapped,
+            ),
+            ArgSpecCache(config).get_argspec(wrapped),
+        )
+        decorated = decorator(wrapped)
+        assert_eq(
+            Signature.make(
+                [
+                    SigParameter(
+                        "args", SigParameter.VAR_POSITIONAL, annotation=UNRESOLVED_VALUE
+                    ),
+                    SigParameter(
+                        "kwargs", SigParameter.VAR_KEYWORD, annotation=UNRESOLVED_VALUE
+                    ),
+                ],
+                callable=decorated,
+            ),
+            ArgSpecCache(config).get_argspec(decorated),
         )
 
 


### PR DESCRIPTION
They might come from the original function and be incorrect.