### PR TITLE
add concrete_values_from_iterable

### DIFF
--- a/pyanalyze/implementation.py
+++ b/pyanalyze/implementation.py
@@ -35,6 +35,7 @@ from .value import (
     Value,
     unite_values,
     flatten_values,
+    replace_known_sequence_value,
 )
 
 import ast
@@ -102,19 +103,6 @@ def flatten_unions(
         reduce(_maybe_or_constraint, constraints),
         reduce(_maybe_or_constraint, no_return_unless),
     )
-
-
-def replace_known_sequence_value(value: Value) -> Value:
-    if isinstance(value, KnownValue):
-        if isinstance(value.val, (list, tuple, set)):
-            return SequenceIncompleteValue(
-                type(value.val), [KnownValue(elt) for elt in value.val]
-            )
-        elif isinstance(value.val, dict):
-            return DictIncompleteValue(
-                [(KnownValue(k), KnownValue(v)) for k, v in value.val.items()]
-            )
-    return value
 
 
 # Implementations of some important functions for use in their ExtendedArgSpecs (see above). These

--- a/pyanalyze/name_check_visitor.py
+++ b/pyanalyze/name_check_visitor.py
@@ -2076,6 +2076,10 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor, CanAssignContext):
                 )
                 with qcore.override(self, "being_assigned", UNRESOLVED_VALUE):
                     return self.generic_visit(node)
+            elif any(isinstance(elt, ast.Starred) for elt in node.elts):
+                # TODO handle * assignment in the left hand side
+                with qcore.override(self, "being_assigned", UNRESOLVED_VALUE):
+                    return self.generic_visit(node)
             elif isinstance(being_assigned, Value):
                 with qcore.override(self, "being_assigned", being_assigned):
                     return self.generic_visit(node)
@@ -2084,8 +2088,8 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor, CanAssignContext):
                 if len(assign_to) != len(being_assigned):
                     self.show_error(
                         node,
-                        f"Length mismatch in unpacking assignment: "
-                        "expected {len(assign_to)} elements but got {self.being_assigned}",
+                        "Length mismatch in unpacking assignment: "
+                        f"expected {len(assign_to)} elements but got {self.being_assigned}",
                         ErrorCode.bad_unpack,
                     )
                     with qcore.override(self, "being_assigned", UNRESOLVED_VALUE):

--- a/pyanalyze/name_check_visitor.py
+++ b/pyanalyze/name_check_visitor.py
@@ -2072,7 +2072,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor, CanAssignContext):
             being_assigned = concrete_values_from_iterable(self.being_assigned, self)
             if being_assigned is None:
                 self.show_error(
-                    node, "Unpacking assignment of a non-iterable", ErrorCode.bad_unpack
+                    node, f"{self.being_assigned} is not iterable", ErrorCode.bad_unpack
                 )
                 with qcore.override(self, "being_assigned", UNRESOLVED_VALUE):
                     return self.generic_visit(node)

--- a/pyanalyze/name_check_visitor.py
+++ b/pyanalyze/name_check_visitor.py
@@ -100,6 +100,7 @@ from pyanalyze.value import (
     Value,
     TypeVarValue,
     CanAssignContext,
+    concrete_values_from_iterable,
 )
 
 T = TypeVar("T")
@@ -2068,52 +2069,37 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor, CanAssignContext):
 
     def _visit_display(self, node, typ):
         if self._is_write_ctx(node.ctx):
-            if any(isinstance(elt, ast.Starred) for elt in node.elts):
-                # TODO handle * assignment in the left hand side
+            being_assigned = concrete_values_from_iterable(self.being_assigned, self)
+            if being_assigned is None:
+                self.show_error(
+                    node, "Unpacking assignment of a non-iterable", ErrorCode.bad_unpack
+                )
                 with qcore.override(self, "being_assigned", UNRESOLVED_VALUE):
                     return self.generic_visit(node)
-
-            if isinstance(self.being_assigned, KnownValue) and isinstance(
-                self.being_assigned.val, (list, tuple)
-            ):
-                being_assigned = [KnownValue(val) for val in self.being_assigned.val]
-            elif isinstance(self.being_assigned, SequenceIncompleteValue):
-                being_assigned = self.being_assigned.members
+            elif isinstance(being_assigned, Value):
+                with qcore.override(self, "being_assigned", being_assigned):
+                    return self.generic_visit(node)
             else:
-                # TODO handle other cases; error if the object is not iterable
-                being_assigned = None
-
-            if being_assigned is not None:
                 assign_to = node.elts
                 if len(assign_to) != len(being_assigned):
-                    # if being_assigned was empty
-                    if len(being_assigned) > 0:
-                        self.show_error(
-                            node,
-                            "Length mismatch in unpacking assignment",
-                            ErrorCode.bad_unpack,
-                        )
+                    self.show_error(
+                        node,
+                        f"Length mismatch in unpacking assignment: "
+                        "expected {len(assign_to)} elements but got {self.being_assigned}",
+                        ErrorCode.bad_unpack,
+                    )
                     with qcore.override(self, "being_assigned", UNRESOLVED_VALUE):
                         self.generic_visit(node)
                 else:
                     for target, value in zip(assign_to, being_assigned):
                         with qcore.override(self, "being_assigned", value):
                             self.visit(target)
-            else:
-                with qcore.override(self, "being_assigned", UNRESOLVED_VALUE):
-                    return self.generic_visit(node)
         else:
             return self._visit_display_read(node, typ)
 
     def _visit_display_read(self, node, typ):
         elts = [self.visit(elt) for elt in node.elts]
-        # If we have something like [*a], give up on identifying the type.
-        if hasattr(ast, "Starred") and any(
-            isinstance(elt, ast.Starred) for elt in node.elts
-        ):
-            return TypedValue(typ)
-        else:
-            return self._maybe_make_sequence(typ, elts, node)
+        return self._maybe_make_sequence(typ, elts, node)
 
     def _maybe_make_sequence(
         self, typ: type, elts: Sequence[Value], node: ast.AST
@@ -2128,7 +2114,31 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor, CanAssignContext):
                 return TypedValue(typ)
             return KnownValue(obj)
         else:
-            return SequenceIncompleteValue(typ, elts)
+            values = []
+            has_unknown_value = False
+            for elt in elts:
+                if isinstance(elt, StarredValue):
+                    vals = concrete_values_from_iterable(elt.value, self)
+                    if vals is None:
+                        self.show_error(
+                            elt.node,
+                            f"{elt.value} is not iterable",
+                            ErrorCode.unsupported_operation,
+                        )
+                        values.append(UNRESOLVED_VALUE)
+                        has_unknown_value = True
+                    elif isinstance(vals, Value):
+                        # single value
+                        has_unknown_value = True
+                        values.append(vals)
+                    else:
+                        values += vals
+                else:
+                    values.append(elt)
+            if has_unknown_value:
+                return GenericValue(typ, [unite_values(*values)])
+            else:
+                return SequenceIncompleteValue(typ, values)
 
     # Operations
 

--- a/pyanalyze/test_value.py
+++ b/pyanalyze/test_value.py
@@ -375,3 +375,42 @@ def test_concrete_values_from_iterable():
         TypedValue(int),
         concrete_values_from_iterable(GenericValue(list, [TypedValue(int)]), _CTX),
     )
+    assert_eq(
+        [
+            MultiValuedValue([KnownValue(1), KnownValue(3)]),
+            MultiValuedValue([KnownValue(2), KnownValue(4)]),
+        ],
+        concrete_values_from_iterable(
+            MultiValuedValue(
+                [
+                    SequenceIncompleteValue(list, [KnownValue(1), KnownValue(2)]),
+                    KnownValue((3, 4)),
+                ]
+            ),
+            _CTX,
+        ),
+    )
+    assert_eq(
+        MultiValuedValue([KnownValue(1), KnownValue(2), TypedValue(int)]),
+        concrete_values_from_iterable(
+            MultiValuedValue(
+                [
+                    SequenceIncompleteValue(list, [KnownValue(1), KnownValue(2)]),
+                    GenericValue(list, [TypedValue(int)]),
+                ]
+            ),
+            _CTX,
+        ),
+    )
+    assert_eq(
+        MultiValuedValue([KnownValue(1), KnownValue(2), KnownValue(3)]),
+        concrete_values_from_iterable(
+            MultiValuedValue(
+                [
+                    SequenceIncompleteValue(list, [KnownValue(1), KnownValue(2)]),
+                    KnownValue((3,)),
+                ]
+            ),
+            _CTX,
+        ),
+    )

--- a/pyanalyze/test_value.py
+++ b/pyanalyze/test_value.py
@@ -18,8 +18,10 @@ from .value import (
     MultiValuedValue,
     SubclassValue,
     CanAssignContext,
+    SequenceIncompleteValue,
     TypeVarMap,
     UNRESOLVED_VALUE,
+    concrete_values_from_iterable,
 )
 
 
@@ -353,4 +355,23 @@ def test_new_type_value():
 def test_io():
     assert_can_assign(
         GenericValue(typing.IO, [UNRESOLVED_VALUE]), TypedValue(io.BytesIO)
+    )
+
+
+def test_concrete_values_from_iterable():
+    assert_is(None, concrete_values_from_iterable(KnownValue(1), _CTX))
+    assert_eq((), concrete_values_from_iterable(KnownValue([]), _CTX))
+    assert_eq(
+        (KnownValue(1), KnownValue(2)),
+        concrete_values_from_iterable(KnownValue((1, 2)), _CTX),
+    )
+    assert_eq(
+        (KnownValue(1), KnownValue(2)),
+        concrete_values_from_iterable(
+            SequenceIncompleteValue(list, [KnownValue(1), KnownValue(2)]), _CTX
+        ),
+    )
+    assert_eq(
+        TypedValue(int),
+        concrete_values_from_iterable(GenericValue(list, [TypedValue(int)]), _CTX),
     )

--- a/pyanalyze/value.py
+++ b/pyanalyze/value.py
@@ -877,6 +877,19 @@ def concrete_values_from_iterable(
     - int -> None
 
     """
+    if isinstance(value, MultiValuedValue):
+        subvals = [concrete_values_from_iterable(val, ctx) for val in value.vals]
+        if any(subval is None for subval in subvals):
+            return None
+        value_subvals = [subval for subval in subvals if isinstance(subval, Value)]
+        seq_subvals = [
+            subval
+            for subval in subvals
+            if subval is not None and not isinstance(subval, Value)
+        ]
+        if not value_subvals and len(set(map(len, seq_subvals))) == 1:
+            return [unite_values(*vals) for vals in zip(*seq_subvals)]
+        return unite_values(*value_subvals, *chain.from_iterable(seq_subvals))
     value = replace_known_sequence_value(value)
     if isinstance(value, SequenceIncompleteValue):
         return value.members

--- a/pyanalyze/value.py
+++ b/pyanalyze/value.py
@@ -856,6 +856,51 @@ def boolean_value(value: Optional[Value]) -> Optional[bool]:
     return None
 
 
+T = TypeVar("T")
+IterableValue = GenericValue(collections.abc.Iterable, [TypeVarValue(T)])
+
+
+def concrete_values_from_iterable(
+    value: Value, ctx: CanAssignContext
+) -> Union[None, Value, Sequence[Value]]:
+    """Return the exact values that can be extracted from an iterable.
+
+    Three possible return types:
+    - None if the argument is not iterable
+    - A sequence of Values if we know the exact types in the iterable
+    - A single Value if we just know that the iterable contains this
+      value, but not the precise number of them.
+
+    Examples:
+    - tuple[int, str] -> (int, str)
+    - tuple[int, ...] -> int
+    - int -> None
+
+    """
+    value = replace_known_sequence_value(value)
+    if isinstance(value, SequenceIncompleteValue):
+        return value.members
+    elif isinstance(value, DictIncompleteValue):
+        return [key for key, _ in value.items]
+    tv_map = IterableValue.can_assign(value, ctx)
+    if tv_map is not None:
+        return tv_map.get(T, UNRESOLVED_VALUE)
+    return None
+
+
+def replace_known_sequence_value(value: Value) -> Value:
+    if isinstance(value, KnownValue):
+        if isinstance(value.val, (list, tuple, set)):
+            return SequenceIncompleteValue(
+                type(value.val), [KnownValue(elt) for elt in value.val]
+            )
+        elif isinstance(value.val, dict):
+            return DictIncompleteValue(
+                [(KnownValue(k), KnownValue(v)) for k, v in value.val.items()]
+            )
+    return value
+
+
 def extract_typevars(value: Value) -> Iterable["TypeVar"]:
     for val in value.walk_values():
         if isinstance(val, TypeVarValue):


### PR DESCRIPTION
This infers more precise types for unpacking assignments (`a, b = c`) and unpacking in collection displays (`[*a, *b]`).

Fixes #72. Fixes part of #66 (not for dictionaries). Works towards fixing #63
(now *args are ignored at a lower level in the stack).