### PR TITLE
don't infer TypedValue(type) for nested classes

### DIFF
--- a/pyanalyze/name_check_visitor.py
+++ b/pyanalyze/name_check_visitor.py
@@ -1073,7 +1073,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor, CanAssignContext):
             if isinstance(cls_obj, KnownValue):
                 return cls_obj
 
-        return TypedValue(type)
+        return UNRESOLVED_VALUE
 
     def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> Value:
         return self.visit_FunctionDef(node, is_coroutine=True)

--- a/pyanalyze/test_name_check_visitor.py
+++ b/pyanalyze/test_name_check_visitor.py
@@ -1427,7 +1427,8 @@ class TestNestedFunction(TestNameCheckVisitorBase):
                 pass
 
             assert_is_value(nested, KnownValue(nested))
-            assert_is_value(NestedClass, TypedValue(type))
+            # Should ideally be something more specific
+            assert_is_value(NestedClass, UNRESOLVED_VALUE)
 
     @assert_passes()
     def test_usage_in_nested_scope():


### PR DESCRIPTION
This causes issues when we use attributes on the nested class that `type` doesn't have. Fixes some false positives from #103.