### PR TITLE
Support for the new version of `typeshed-client`

### DIFF
--- a/pyanalyze/arg_spec.py
+++ b/pyanalyze/arg_spec.py
@@ -578,7 +578,14 @@ _TYPING_ALIASES = {
 class TypeshedFinder(object):
     def __init__(self, verbose: bool = True) -> None:
         self.verbose = verbose
-        self.resolver = typeshed_client.Resolver(version=sys.version_info[:2])
+        # Dealing with upcoming typeshed-client change; TODO require the new version
+        # once it is released.
+        try:
+            # static analysis: ignore[incompatible_call]
+            resolver = typeshed_client.Resolver(version=sys.version_info[:2])
+        except TypeError:
+            resolver = typeshed_client.Resolver()
+        self.resolver = resolver
         self._assignment_cache = {}
 
     def log(self, message: str, obj: object) -> None:

--- a/pyanalyze/arg_spec.py
+++ b/pyanalyze/arg_spec.py
@@ -59,7 +59,6 @@ from typing import (
     Dict,
     List,
     TypeVar,
-    NewType,
 )
 from typing_extensions import Protocol
 import typing_inspect

--- a/pyanalyze/arg_spec.py
+++ b/pyanalyze/arg_spec.py
@@ -456,7 +456,7 @@ class ArgSpecCache:
                     return PropertyArgSpec(obj, return_value=fget_argspec.return_value)
             return PropertyArgSpec(obj)
 
-        raise TypeError("%r object is not callable" % (obj,))
+        return None
 
     def _safe_get_signature(self, obj: Any) -> Optional[inspect.Signature]:
         """Wrapper around inspect.getargspec that catches TypeErrors."""

--- a/pyanalyze/name_check_visitor.py
+++ b/pyanalyze/name_check_visitor.py
@@ -3601,11 +3601,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor, CanAssignContext):
         self, obj: object, node: ast.AST, name: Optional[str] = None
     ) -> MaybeSignature:
         """Given a Python object obj retrieved from node, try to get its argspec."""
-        try:
-            return self.arg_spec_cache.get_argspec(obj, name=name, logger=self.log)
-        except TypeError as e:
-            self._show_error_if_checking(node, e, ErrorCode.not_callable)
-            return None
+        return self.arg_spec_cache.get_argspec(obj, name=name, logger=self.log)
 
     # Attribute checking
 

--- a/pyanalyze/name_check_visitor.py
+++ b/pyanalyze/name_check_visitor.py
@@ -3574,7 +3574,12 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor, CanAssignContext):
             # other exceptions from __getattr__.
             except Exception:
                 name = None
-            return self._get_argspec(callee_wrapped.val, node, name=name)
+            argspec = self._get_argspec(callee_wrapped.val, node, name=name)
+            if argspec is None:
+                method_object = self.get_attribute(node, "__call__", callee_wrapped)
+                if method_object is UNINITIALIZED_VALUE:
+                    self._show_error_if_checking(node, f"{callee_wrapped} is not callable", ErrorCode.not_callable)
+            return argspec
         elif isinstance(callee_wrapped, UnboundMethodValue):
             method = callee_wrapped.get_method()
             if method is not None:

--- a/pyanalyze/name_check_visitor.py
+++ b/pyanalyze/name_check_visitor.py
@@ -3518,7 +3518,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor, CanAssignContext):
             try:
                 result = callee_wrapped.val(
                     *[arg.val for arg in args],
-                    **{key: value.val for key, value in keywords}
+                    **{key: value.val for key, value in keywords},
                 )
             except Exception as e:
                 self.log(logging.INFO, "exception calling", (callee_wrapped, e))
@@ -3578,7 +3578,11 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor, CanAssignContext):
             if argspec is None:
                 method_object = self.get_attribute(node, "__call__", callee_wrapped)
                 if method_object is UNINITIALIZED_VALUE:
-                    self._show_error_if_checking(node, f"{callee_wrapped} is not callable", ErrorCode.not_callable)
+                    self._show_error_if_checking(
+                        node,
+                        f"{callee_wrapped} is not callable",
+                        ErrorCode.not_callable,
+                    )
             return argspec
         elif isinstance(callee_wrapped, UnboundMethodValue):
             method = callee_wrapped.get_method()
@@ -3698,7 +3702,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor, CanAssignContext):
         find_unused_attributes=False,
         attribute_checker=None,
         unused_finder=None,
-        **kwargs
+        **kwargs,
     ):
         attribute_checker_enabled = settings[ErrorCode.attribute_is_never_set]
         if "arg_spec_cache" not in kwargs:
@@ -3726,7 +3730,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor, CanAssignContext):
                 else inner_attribute_checker,
                 unused_finder=inner_unused_finder,
                 settings=settings,
-                **kwargs
+                **kwargs,
             )
         if unused_finder is not None:
             for unused_object in unused_finder.get_unused_objects():

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
             "qcore>=0.5.1",
             "ast_decompiler>=0.4.0",
             "six>=1.10.0",
-            "typeshed_client>=0.4.1,<1.0",
+            "typeshed_client==1.0.0rc1",
             "typing_inspect>=0.5.0",
             "typing_extensions",
             "mypy_extensions",

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
             "qcore>=0.5.1",
             "ast_decompiler>=0.4.0",
             "six>=1.10.0",
-            "typeshed_client==1.0.0rc1",
+            "typeshed_client>=1.0.0",
             "typing_inspect>=0.5.0",
             "typing_extensions",
             "mypy_extensions",


### PR DESCRIPTION
Notably, this includes support for recognizing NewTypes in stubs, which is necessary because typeshed-client now picks up the stubs for qcore, which include some NewTypes.