### PR TITLE
add support for Annotated

### DIFF
--- a/pyanalyze/analysis_lib.py
+++ b/pyanalyze/analysis_lib.py
@@ -5,7 +5,10 @@ Commonly useful components for static analysis tools.
 """
 import ast
 import os
-from typing import List, Callable, Optional, Set, TypeVar, Container
+from typing import List, Callable, Optional, Set, TypeVar, Container, Type, Iterable
+from typing_extensions import Annotated
+
+from .extensions import ParameterTypeGuard
 
 T = TypeVar("T")
 
@@ -99,3 +102,10 @@ def safe_in(item: T, collection: Container[T]) -> bool:
         return item in collection
     except Exception:
         return False
+
+
+def all_of_type(
+    elts: Iterable[object], typ: Type[T]
+) -> Annotated[bool, ParameterTypeGuard["elts", Iterable[T]]]:
+    """Returns whether all elements of elts are instances of typ."""
+    return all(isinstance(elt, typ) for elt in elts)

--- a/pyanalyze/annotations.py
+++ b/pyanalyze/annotations.py
@@ -300,14 +300,12 @@ def _type_from_value(value: Value, ctx: Context) -> Value:
             return unite_values(
                 KnownValue(None), _type_from_value(value.members[0], ctx)
             )
-        elif root is typing.Type:
+        elif root is typing.Type or root is type:
             if len(value.members) != 1:
                 ctx.show_error("Type[] takes only one argument")
                 return UNRESOLVED_VALUE
             argument = _type_from_value(value.members[0], ctx)
-            if isinstance(argument, TypedValue) and isinstance(argument.typ, type):
-                return SubclassValue(argument.typ)
-            return TypedValue(type)
+            return SubclassValue(argument)
         elif is_typing_name(root, "Annotated"):
             origin, *metadata = value.members
             return _make_annotated(_type_from_value(origin, ctx), metadata, ctx)
@@ -514,13 +512,7 @@ def _value_of_origin_args(
     origin: object, args: Sequence[object], val: object, ctx: Context
 ) -> Value:
     if origin is typing.Type or origin is type:
-        if isinstance(args[0], type):
-            return SubclassValue(args[0])
-        elif args[0] is typing.Any:
-            return TypedValue(type)
-        else:
-            # Perhaps a forward reference
-            return UNRESOLVED_VALUE
+        return SubclassValue(_type_from_runtime(args[0], ctx))
     elif origin is typing.Tuple or origin is tuple:
         if not args:
             return TypedValue(tuple)

--- a/pyanalyze/annotations.py
+++ b/pyanalyze/annotations.py
@@ -305,7 +305,7 @@ def _type_from_value(value: Value, ctx: Context) -> Value:
                 ctx.show_error("Type[] takes only one argument")
                 return UNRESOLVED_VALUE
             argument = _type_from_value(value.members[0], ctx)
-            return SubclassValue(argument)
+            return SubclassValue.make(argument)
         elif is_typing_name(root, "Annotated"):
             origin, *metadata = value.members
             return _make_annotated(_type_from_value(origin, ctx), metadata, ctx)
@@ -512,7 +512,7 @@ def _value_of_origin_args(
     origin: object, args: Sequence[object], val: object, ctx: Context
 ) -> Value:
     if origin is typing.Type or origin is type:
-        return SubclassValue(_type_from_runtime(args[0], ctx))
+        return SubclassValue.make(_type_from_runtime(args[0], ctx))
     elif origin is typing.Tuple or origin is tuple:
         if not args:
             return TypedValue(tuple)

--- a/pyanalyze/attributes.py
+++ b/pyanalyze/attributes.py
@@ -13,6 +13,7 @@ from typing import Any, Tuple, Optional
 
 from .annotations import type_from_runtime
 from .value import (
+    AnnotatedValue,
     Value,
     KnownValue,
     GenericValue,
@@ -65,6 +66,8 @@ def get_attribute(ctx: AttrContext) -> Value:
         return _get_attribute_from_subclass(root_value.typ, ctx)
     elif isinstance(root_value, UnboundMethodValue):
         return _get_attribute_from_unbound(root_value, ctx)
+    elif isinstance(root_value, AnnotatedValue):
+        return get_attribute(root_value.value, ctx)
     elif root_value is UNRESOLVED_VALUE or isinstance(root_value, VariableNameValue):
         return UNRESOLVED_VALUE
     elif isinstance(root_value, MultiValuedValue):

--- a/pyanalyze/attributes.py
+++ b/pyanalyze/attributes.py
@@ -58,6 +58,8 @@ def get_attribute(ctx: AttrContext) -> Value:
     root_value = ctx.root_value
     if isinstance(root_value, TypeVarValue):
         root_value = root_value.get_fallback_value()
+    elif isinstance(root_value, AnnotatedValue):
+        root_value = root_value.value
     if isinstance(root_value, KnownValue):
         return _get_attribute_from_known(root_value.val, ctx)
     elif isinstance(root_value, TypedValue):
@@ -66,8 +68,6 @@ def get_attribute(ctx: AttrContext) -> Value:
         return _get_attribute_from_subclass(root_value.typ, ctx)
     elif isinstance(root_value, UnboundMethodValue):
         return _get_attribute_from_unbound(root_value, ctx)
-    elif isinstance(root_value, AnnotatedValue):
-        return get_attribute(root_value.value, ctx)
     elif root_value is UNRESOLVED_VALUE or isinstance(root_value, VariableNameValue):
         return UNRESOLVED_VALUE
     elif isinstance(root_value, MultiValuedValue):

--- a/pyanalyze/attributes.py
+++ b/pyanalyze/attributes.py
@@ -65,7 +65,12 @@ def get_attribute(ctx: AttrContext) -> Value:
     elif isinstance(root_value, TypedValue):
         return _get_attribute_from_typed(root_value.typ, ctx)
     elif isinstance(root_value, SubclassValue):
-        return _get_attribute_from_subclass(root_value.typ, ctx)
+        if isinstance(root_value.typ, TypedValue):
+            return _get_attribute_from_subclass(root_value.typ.typ, ctx)
+        elif root_value.typ is UNRESOLVED_VALUE:
+            return UNRESOLVED_VALUE
+        else:
+            return _get_attribute_from_known(type, ctx)
     elif isinstance(root_value, UnboundMethodValue):
         return _get_attribute_from_unbound(root_value, ctx)
     elif root_value is UNRESOLVED_VALUE or isinstance(root_value, VariableNameValue):
@@ -89,7 +94,7 @@ def _get_attribute_from_subclass(
     elif ctx.attr == "__dict__":
         return TypedValue(dict)
     elif ctx.attr == "__bases__":
-        return GenericValue(tuple, [SubclassValue(object)])
+        return GenericValue(tuple, [SubclassValue(TypedValue(object))])
     result, should_unwrap = _get_attribute_from_mro(typ, ctx)
     if should_unwrap:
         result = _unwrap_value_from_subclass(result, ctx)

--- a/pyanalyze/extensions.py
+++ b/pyanalyze/extensions.py
@@ -19,7 +19,7 @@ class _ParameterTypeGuardMeta(type):
         return ParameterTypeGuard(params[0], params[1])
 
 
-@dataclass
+@dataclass(frozen=True)
 class ParameterTypeGuard(metaclass=_ParameterTypeGuardMeta):
     """A guard on an arbitrary parameter.
 

--- a/pyanalyze/extensions.py
+++ b/pyanalyze/extensions.py
@@ -1,0 +1,34 @@
+"""
+
+Extensions to the type system supported by pyanalyze.
+
+"""
+from dataclasses import dataclass
+from typing import Tuple
+
+
+class _ParameterTypeGuardMeta(type):
+    def __getitem__(self, params: Tuple[str, object]) -> "ParameterTypeGuard":
+        if not isinstance(params, tuple) or len(params) < 2:
+            raise TypeError(
+                "ParameterTypeGuard[...] should be instantiated "
+                "with two arguments (a variable name and a type)."
+            )
+        if not isinstance(params[0], str):
+            raise TypeError("The first argument to ParameterTypeGuard must be a string")
+        return ParameterTypeGuard(params[0], params[1])
+
+
+@dataclass
+class ParameterTypeGuard(metaclass=_ParameterTypeGuardMeta):
+    """A guard on an arbitrary parameter.
+
+    Example usage:
+
+        def is_int(arg: object) -> Annotated[bool, ParameterTypeGuard["arg", int]]:
+            return isinstance(arg, int)
+
+    """
+
+    varname: str
+    guarded_type: object

--- a/pyanalyze/extensions.py
+++ b/pyanalyze/extensions.py
@@ -4,7 +4,9 @@ Extensions to the type system supported by pyanalyze.
 
 """
 from dataclasses import dataclass
-from typing import Tuple
+from typing import Tuple, TypeVar
+
+_T = TypeVar("_T")
 
 
 class _ParameterTypeGuardMeta(type):

--- a/pyanalyze/extensions.py
+++ b/pyanalyze/extensions.py
@@ -4,9 +4,7 @@ Extensions to the type system supported by pyanalyze.
 
 """
 from dataclasses import dataclass
-from typing import Tuple, TypeVar
-
-_T = TypeVar("_T")
+from typing import Tuple
 
 
 class _ParameterTypeGuardMeta(type):

--- a/pyanalyze/find_unused.py
+++ b/pyanalyze/find_unused.py
@@ -14,6 +14,7 @@ import __future__
 
 from .analysis_lib import safe_in
 from .config import Config
+from . import extensions
 
 T = TypeVar("T")
 
@@ -45,6 +46,7 @@ def test_helper(obj: T) -> T:
 # so it doesn't itself get marked as unused
 used(used)
 used(test_helper)
+used(extensions)
 
 
 class _UsageKind(enum.IntEnum):

--- a/pyanalyze/format_strings.py
+++ b/pyanalyze/format_strings.py
@@ -27,6 +27,7 @@ from typing_extensions import Literal
 
 from .error_code import ErrorCode
 from .value import (
+    AnnotatedValue,
     KnownValue,
     DictIncompleteValue,
     SequenceIncompleteValue,
@@ -145,6 +146,8 @@ class ConversionSpecifier:
 
     def accept(self, arg: Value) -> Iterable[str]:
         """Produces any errors from passing the given object to this specifier."""
+        if isinstance(arg, AnnotatedValue):
+            arg = arg.value
         if arg is UNRESOLVED_VALUE or isinstance(arg, MultiValuedValue):
             return
         if self.conversion_type in _NUMERIC_CONVERSION_TYPES:
@@ -317,6 +320,8 @@ class PercentFormatString:
 
     def accept_tuple_args(self, args: Value) -> Iterable[str]:
         specifiers = list(self.get_serial_specifiers())
+        if isinstance(args, AnnotatedValue):
+            args = args.value
         if args.is_type(tuple):
             if isinstance(args, SequenceIncompleteValue):
                 all_args = args.members

--- a/pyanalyze/implementation.py
+++ b/pyanalyze/implementation.py
@@ -225,8 +225,10 @@ def _super_impl(
                 )
                 return UNRESOLVED_VALUE
             else:
-                if isinstance(first_arg, SubclassValue):
-                    return KnownValue(super(current_class, first_arg.typ))
+                if isinstance(first_arg, SubclassValue) and isinstance(
+                    first_arg.typ, TypedValue
+                ):
+                    return KnownValue(super(current_class, first_arg.typ.typ))
                 elif isinstance(first_arg, KnownValue):
                     return KnownValue(super(current_class, first_arg.val))
                 elif isinstance(first_arg, TypedValue):
@@ -251,8 +253,8 @@ def _super_impl(
     if isinstance(obj, TypedValue) and obj.typ is not type:
         instance_type = obj.typ
         is_value = True
-    elif isinstance(obj, SubclassValue):
-        instance_type = obj.typ
+    elif isinstance(obj, SubclassValue) and isinstance(obj.typ, TypedValue):
+        instance_type = obj.typ.typ
         is_value = False
     else:
         return UNRESOLVED_VALUE

--- a/pyanalyze/name_check_visitor.py
+++ b/pyanalyze/name_check_visitor.py
@@ -3573,7 +3573,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor, CanAssignContext):
                 # if all arguments are KnownValues and the class is whitelisted, instantiate it
                 if issubclass(
                     callee_val, self.config.CLASSES_SAFE_TO_INSTANTIATE
-                ) and self._can_perform_call( arg_values, kw_values):
+                ) and self._can_perform_call(arg_values, kw_values):
                     return_value = self._try_perform_call(
                         # TODO make these unnecessary
                         callee_val,
@@ -3587,7 +3587,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor, CanAssignContext):
                     return_value = TypedValue(callee_val)
             elif safe_in(
                 callee_val, self.config.FUNCTIONS_SAFE_TO_CALL
-            ) and self._can_perform_call( arg_values, kw_values):
+            ) and self._can_perform_call(arg_values, kw_values):
                 return_value = self._try_perform_call(
                     callee_val,
                     node,
@@ -3696,10 +3696,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor, CanAssignContext):
         ):
             return_value = self._argspec_to_retval[id(extended_argspec)]
 
-        if (
-            allow_call
-            and isinstance(callee_wrapped, KnownValue)
-        ):
+        if allow_call and isinstance(callee_wrapped, KnownValue):
             arg_values = [arg.value for arg in args]
             kw_values = [(kw, composite.value) for kw, composite in keywords]
             if self._can_perform_call(arg_values, kw_values):

--- a/pyanalyze/name_check_visitor.py
+++ b/pyanalyze/name_check_visitor.py
@@ -2823,7 +2823,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor, CanAssignContext):
             num = nums[0] if len(set(nums)) == 1 else None
             return unite_values(*vals), num
         elif isinstance(iterated, AnnotatedValue):
-            return self._member_value_of_generator(iterated.value, node)
+            return self._member_value_of_iterator_val(iterated.value, node)
         else:
             tv_map = IterableValue.can_assign(iterated, self)
             if tv_map is None:

--- a/pyanalyze/name_check_visitor.py
+++ b/pyanalyze/name_check_visitor.py
@@ -2793,7 +2793,10 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor, CanAssignContext):
         self, iterated: Composite, node: ast.AST
     ) -> Tuple[Value, None]:
         iterator = self._check_dunder_call(node, iterated, "__aiter__", [])
-        return self._check_dunder_call(node, Composite(iterator, None), "__anext__", []), None
+        return (
+            self._check_dunder_call(node, Composite(iterator, None), "__anext__", []),
+            None,
+        )
 
     def _member_value_of_iterator_val(
         self, iterated: Value, node: ast.AST
@@ -3573,7 +3576,11 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor, CanAssignContext):
                 callee_val, self.config.FUNCTIONS_SAFE_TO_CALL
             ) and self._can_perform_call(node, arg_values, kw_values):
                 return_value = self._try_perform_call(
-                    callee_val, node, cast(Any, arg_values), cast(Any, kw_values), return_value
+                    callee_val,
+                    node,
+                    cast(Any, arg_values),
+                    cast(Any, kw_values),
+                    return_value,
                 )
 
         return return_value, constraint

--- a/pyanalyze/signature.py
+++ b/pyanalyze/signature.py
@@ -222,7 +222,6 @@ class Signature:
         constraints = []
         if isinstance(return_value, AnnotatedValue):
             for guard in return_value.get_metadata_of_type(ParameterTypeGuardExtension):
-                print("GUARD", guard)
                 if guard.varname in bound_args.arguments:
                     composite = bound_args.arguments[guard.varname]
                     if (

--- a/pyanalyze/signature.py
+++ b/pyanalyze/signature.py
@@ -253,7 +253,6 @@ class Signature:
         the local variables to validate types and keyword-only arguments.
 
         """
-        print("SIG", self)
         call_args = []
         call_kwargs = {}
         for composite, label in args:

--- a/pyanalyze/signature.py
+++ b/pyanalyze/signature.py
@@ -4,9 +4,19 @@ Wrappers around Signature objects.
 
 """
 
+from functools import reduce
+from .extensions import ParameterTypeGuard
 from .error_code import ErrorCode
-from .stacked_scopes import NULL_CONSTRAINT, AbstractConstraint
+from .stacked_scopes import (
+    AndConstraint,
+    Composite,
+    Constraint,
+    ConstraintType,
+    NULL_CONSTRAINT,
+    AbstractConstraint
+)
 from .value import (
+    AnnotatedValue,
     KnownValue,
     SequenceIncompleteValue,
     DictIncompleteValue,
@@ -72,7 +82,7 @@ KWARGS = qcore.MarkerObject("**kwargs")
 # Representation of a single argument to a call. Second member is
 # None for positional args, str for keyword args, ARGS for *args, KWARGS
 # for **kwargs.
-Argument = Tuple[Value, Union[None, str, Literal[ARGS], Literal[KWARGS]]]
+Argument = Tuple[Composite, Union[None, str, Literal[ARGS], Literal[KWARGS]]]
 
 
 def clean_up_implementation_fn_return(
@@ -111,14 +121,18 @@ class SigParameter(inspect.Parameter):
         name: str,
         kind: inspect._ParameterKind = inspect.Parameter.POSITIONAL_OR_KEYWORD,
         *,
-        default: Optional[Value] = None,
+        default: Union[None, Value, Literal[EMPTY]] = None,
         annotation: Optional[Value] = None,
     ) -> None:
         if default is None:
-            default = EMPTY
+            default_composite = EMPTY
+        elif isinstance(default, Value):
+            default_composite = Composite(default, None)
+        else:
+            default_composite = default
         if annotation is None:
             annotation = EMPTY
-        super().__init__(name, kind, default=default, annotation=annotation)
+        super().__init__(name, kind, default=default_composite, annotation=annotation)
 
 
 @dataclass
@@ -166,7 +180,7 @@ class Signature:
         node: ast.AST,
         typevar_map: TypeVarMap,
     ) -> bool:
-        if param.annotation is not EMPTY and var_value is not param.default:
+        if param.annotation is not EMPTY and not (isinstance(param.default, Composite) and var_value is param.default.value):
             if typevar_map:
                 param_typ = param.annotation.substitute_typevars(typevar_map)
             else:
@@ -184,14 +198,46 @@ class Signature:
     def _translate_bound_arg(self, argument: Any) -> Value:
         if argument is EMPTY:
             return UNRESOLVED_VALUE
+        elif isinstance(argument, Composite):
+            return argument.value
         elif isinstance(argument, tuple):
-            return SequenceIncompleteValue(tuple, argument)
+            return SequenceIncompleteValue(
+                tuple, [composite.value for composite in argument]
+            )
         elif isinstance(argument, dict):
             return DictIncompleteValue(
-                [(KnownValue(key), value) for key, value in argument.items()]
+                [
+                    (KnownValue(key), composite.value)
+                    for key, composite in argument.items()
+                ]
             )
         else:
-            return argument
+            raise TypeError(repr(argument))
+
+    def _apply_annotated_constraints(
+        self, return_value: Value, bound_args: inspect.BoundArguments
+    ) -> Tuple[Value, AbstractConstraint, AbstractConstraint]:
+        constraints = []
+        if isinstance(return_value, AnnotatedValue):
+            for guard in return_value.get_metadata_of_type(ParameterTypeGuard):
+                if guard.varname in bound_args.arguments:
+                    composite = bound_args.arguments[guard.varname]
+                    if (
+                        isinstance(composite, Composite)
+                        and composite.varname is not None
+                    ):
+                        constraint = Constraint(
+                            composite.varname,
+                            ConstraintType.is_value_object,
+                            True,
+                            guard.value,
+                        )
+                        constraints.append(constraint)
+        if constraints:
+            constraint = reduce(AndConstraint, constraints)
+        else:
+            constraint = NULL_CONSTRAINT
+        return return_value, constraint, NULL_CONSTRAINT
 
     def check_call(
         self, args: Iterable[Argument], visitor: "NameCheckVisitor", node: ast.AST
@@ -206,17 +252,17 @@ class Signature:
         """
         call_args = []
         call_kwargs = {}
-        for arg, label in args:
+        for composite, label in args:
             if label is None:
-                call_args.append(arg)
+                call_args.append(composite)
             elif isinstance(label, str):
-                call_kwargs[label] = arg
+                call_kwargs[label] = composite
             elif label is ARGS or label is KWARGS:
                 # TODO handle these:
                 # - type check that they are iterables/mappings
                 # - if it's a KnownValue or SequenceIncompleteValue, just add to call_args
                 # - else do something smart to still typecheck the call
-                self.log(logging.DEBUG, "Ignoring call with *args/**kwargs", arg)
+                self.log(logging.DEBUG, "Ignoring call with *args/**kwargs", composite)
                 return UNRESOLVED_VALUE, NULL_CONSTRAINT, NULL_CONSTRAINT
         try:
             bound_args = self.signature.bind(*call_args, **call_kwargs)
@@ -269,7 +315,7 @@ class Signature:
         elif return_value is EMPTY:
             return UNRESOLVED_VALUE, NULL_CONSTRAINT, NULL_CONSTRAINT
         else:
-            return return_value, NULL_CONSTRAINT, NULL_CONSTRAINT
+            return self._apply_annotated_constraints(return_value, bound_args)
 
     @classmethod
     def make(
@@ -312,7 +358,10 @@ class BoundMethodSignature:
         self, args: Iterable[Argument], visitor: "NameCheckVisitor", node: ast.AST
     ) -> Tuple[Value, AbstractConstraint, AbstractConstraint]:
         return self.signature.check_call(
-            [(self.self_value, None), *args], visitor, node
+            # TODO get a composite
+            [(Composite(self.self_value, None), None), *args],
+            visitor,
+            node,
         )
 
     def has_return_value(self) -> bool:

--- a/pyanalyze/stacked_scopes.py
+++ b/pyanalyze/stacked_scopes.py
@@ -34,6 +34,7 @@ from typing import (
     Iterable,
     Iterator,
     List,
+    NamedTuple,
     Sequence,
     Optional,
     Set,
@@ -101,6 +102,11 @@ SubScope = Dict[Varname, List[Node]]
 
 # Type for Constraint.value if constraint type is predicate
 # PredicateFunc = Callable[[Value, bool], Optional[Value]]
+
+
+class Composite(NamedTuple):
+    value: Value
+    varname: Optional[Varname]
 
 
 @dataclass(frozen=True)

--- a/pyanalyze/stacked_scopes.py
+++ b/pyanalyze/stacked_scopes.py
@@ -250,11 +250,13 @@ class Constraint(AbstractConstraint):
                     if not safe_issubclass(value.typ, self.value):
                         yield value
             elif isinstance(value, SubclassValue):
-                if self.positive:
-                    if isinstance(value.typ, self.value):
+                if not isinstance(value.typ, TypedValue):
+                    yield value
+                elif self.positive:
+                    if isinstance(value.typ.typ, self.value):
                         yield value
                 else:
-                    if not isinstance(value.typ, self.value):
+                    if not isinstance(value.typ.typ, self.value):
                         yield value
 
         elif self.constraint_type == ConstraintType.is_value:
@@ -269,8 +271,10 @@ class Constraint(AbstractConstraint):
                     if isinstance(self.value, value.typ):
                         yield known_val
                 elif isinstance(value, SubclassValue):
-                    if isinstance(self.value, type) and safe_issubclass(
-                        self.value, value.typ
+                    if (
+                        isinstance(value.typ, TypedValue)
+                        and isinstance(self.value, type)
+                        and safe_issubclass(self.value, value.typ.typ)
                     ):
                         yield known_val
             else:

--- a/pyanalyze/test_annotations.py
+++ b/pyanalyze/test_annotations.py
@@ -1,5 +1,4 @@
 # static analysis: ignore
-from typing import Annotated
 from .test_name_check_visitor import TestNameCheckVisitorBase
 from .test_node_visitor import skip_before, assert_passes, assert_fails
 from .implementation import assert_is_value
@@ -386,8 +385,8 @@ def f(x: int, y: List[str]):
         from typing import Type
 
         def capybara(x: Type[str], y: "Type[int]"):
-            assert_is_value(x, SubclassValue(str))
-            assert_is_value(y, SubclassValue(int))
+            assert_is_value(x, SubclassValue(TypedValue(str)))
+            assert_is_value(y, SubclassValue(TypedValue(int)))
 
     @skip_before((3, 9))
     @assert_passes()

--- a/pyanalyze/test_annotations.py
+++ b/pyanalyze/test_annotations.py
@@ -455,9 +455,12 @@ class TestAnnotated(TestNameCheckVisitorBase):
                 quoted,
                 AnnotatedValue(TypedValue(int), [KnownValue(int), KnownValue(str)]),
             )
-            assert_is_value(nested, AnnotatedValue(TypedValue(int), [KnownValue(1), KnownValue(2)]))
             assert_is_value(
-                nested_quoted, AnnotatedValue(TypedValue(int), [KnownValue(1), KnownValue(2)])
+                nested, AnnotatedValue(TypedValue(int), [KnownValue(1), KnownValue(2)])
+            )
+            assert_is_value(
+                nested_quoted,
+                AnnotatedValue(TypedValue(int), [KnownValue(1), KnownValue(2)]),
             )
 
     @skip_before((3, 9))
@@ -480,7 +483,10 @@ class TestAnnotated(TestNameCheckVisitorBase):
                 quoted,
                 AnnotatedValue(TypedValue(int), [KnownValue(int), KnownValue(str)]),
             )
-            assert_is_value(nested, AnnotatedValue(TypedValue(int), [KnownValue(1), KnownValue(2)]))
             assert_is_value(
-                nested_quoted, AnnotatedValue(TypedValue(int), [KnownValue(1), KnownValue(2)])
+                nested, AnnotatedValue(TypedValue(int), [KnownValue(1), KnownValue(2)])
+            )
+            assert_is_value(
+                nested_quoted,
+                AnnotatedValue(TypedValue(int), [KnownValue(1), KnownValue(2)]),
             )

--- a/pyanalyze/test_annotations.py
+++ b/pyanalyze/test_annotations.py
@@ -4,6 +4,7 @@ from .test_node_visitor import skip_before, assert_passes, assert_fails
 from .implementation import assert_is_value
 from .error_code import ErrorCode
 from .value import (
+    AnnotatedValue,
     KnownValue,
     MultiValuedValue,
     NewTypeValue,
@@ -432,3 +433,54 @@ def capybara(x: int | None, y: int | str) -> None:
 
         def f():
             Capybara(x=3)
+
+
+class TestAnnotated(TestNameCheckVisitorBase):
+    @assert_passes()
+    def test_typing_extensions(self):
+        from typing_extensions import Annotated
+
+        obj = object()
+
+        def capybara(
+            x: Annotated[int, "stuff"],
+            y: Annotated[int, obj],
+            quoted: "Annotated[int, int, str]",
+            nested: Annotated[Annotated[int, 1], 2],
+            nested_quoted: "Annotated[Annotated[int, 1], 2]",
+        ) -> None:
+            assert_is_value(x, AnnotatedValue(TypedValue(int), [KnownValue("stuff")]))
+            assert_is_value(y, AnnotatedValue(TypedValue(int), [KnownValue(obj)]))
+            assert_is_value(
+                quoted,
+                AnnotatedValue(TypedValue(int), [KnownValue(int), KnownValue(str)]),
+            )
+            assert_is_value(nested, AnnotatedValue(TypedValue(int), [KnownValue(1), KnownValue(2)]))
+            assert_is_value(
+                nested_quoted, AnnotatedValue(TypedValue(int), [KnownValue(1), KnownValue(2)])
+            )
+
+    @skip_before((3, 9))
+    @assert_passes()
+    def test_typing(self):
+        from typing import Annotated
+
+        obj = object()
+
+        def capybara(
+            x: Annotated[int, "stuff"],
+            y: Annotated[int, obj],
+            quoted: "Annotated[int, int, str]",
+            nested: Annotated[Annotated[int, 1], 2],
+            nested_quoted: "Annotated[Annotated[int, 1], 2]",
+        ) -> None:
+            assert_is_value(x, AnnotatedValue(TypedValue(int), [KnownValue("stuff")]))
+            assert_is_value(y, AnnotatedValue(TypedValue(int), [KnownValue(obj)]))
+            assert_is_value(
+                quoted,
+                AnnotatedValue(TypedValue(int), [KnownValue(int), KnownValue(str)]),
+            )
+            assert_is_value(nested, AnnotatedValue(TypedValue(int), [KnownValue(1), KnownValue(2)]))
+            assert_is_value(
+                nested_quoted, AnnotatedValue(TypedValue(int), [KnownValue(1), KnownValue(2)])
+            )

--- a/pyanalyze/test_name_check_visitor.py
+++ b/pyanalyze/test_name_check_visitor.py
@@ -24,6 +24,7 @@ from .implementation import assert_is_value, dump_value
 from .error_code import DISABLED_IN_TESTS, ErrorCode
 from .test_config import TestConfig
 from .value import (
+    AnnotatedValue,
     AsyncTaskIncompleteValue,
     DictIncompleteValue,
     KnownValue,
@@ -123,6 +124,7 @@ def _make_module(code_str):
         GenericValue=GenericValue,
         KnownValue=KnownValue,
         MultiValuedValue=MultiValuedValue,
+        AnnotatedValue=AnnotatedValue,
         SequenceIncompleteValue=SequenceIncompleteValue,
         TypedValue=TypedValue,
         UnboundMethodValue=UnboundMethodValue,

--- a/pyanalyze/test_name_check_visitor.py
+++ b/pyanalyze/test_name_check_visitor.py
@@ -516,10 +516,10 @@ def run():
     def test_cls_type_inference(self):
         class OldStyle:
             def __init_subclass__(cls):
-                assert_is_value(cls, SubclassValue(OldStyle))
+                assert_is_value(cls, SubclassValue(TypedValue(OldStyle)))
 
             def __new__(cls):
-                assert_is_value(cls, SubclassValue(OldStyle))
+                assert_is_value(cls, SubclassValue(TypedValue(OldStyle)))
 
     @assert_passes()
     def test_cls_type_inference(self):
@@ -716,7 +716,7 @@ class TestSubclassValue(TestNameCheckVisitorBase):
         TI = Type[int]
 
         def capybara(x: TI, y: str):
-            assert_is_value(x, SubclassValue(int))
+            assert_is_value(x, SubclassValue(TypedValue(int)))
             assert_is_value(y, TypedValue(str))
 
     @only_before((3, 7))

--- a/pyanalyze/test_value.py
+++ b/pyanalyze/test_value.py
@@ -71,7 +71,7 @@ def test_known_value() -> None:
     assert_cannot_assign(val, TypedValue(int))
     assert_can_assign(val, MultiValuedValue([val, UNRESOLVED_VALUE]))
     assert_cannot_assign(val, MultiValuedValue([val, TypedValue(int)]))
-    assert_cannot_assign(KnownValue(int), SubclassValue(int))
+    assert_cannot_assign(KnownValue(int), SubclassValue(TypedValue(int)))
 
 
 def test_unbound_method_value() -> None:
@@ -127,8 +127,8 @@ def test_typed_value() -> None:
     assert_cannot_assign(float_val, TypedValue(str))
     assert_can_assign(float_val, TypedValue(mock.Mock))
 
-    assert_cannot_assign(float_val, SubclassValue(float))
-    assert_can_assign(TypedValue(type), SubclassValue(float))
+    assert_cannot_assign(float_val, SubclassValue(TypedValue(float)))
+    assert_can_assign(TypedValue(type), SubclassValue(TypedValue(float)))
 
 
 @runtime_checkable
@@ -166,17 +166,18 @@ def test_callable() -> None:
 
 
 def test_subclass_value() -> None:
-    val = SubclassValue(int)
+    val = SubclassValue(TypedValue(int))
     assert_can_assign(val, KnownValue(int))
     assert_can_assign(val, KnownValue(bool))
     assert_cannot_assign(val, KnownValue(str))
     assert_can_assign(val, TypedValue(type))
     assert_cannot_assign(val, TypedValue(int))
-    assert_can_assign(val, SubclassValue(bool))
-    assert_cannot_assign(val, SubclassValue(str))
-    val = value.SubclassValue(str)
+    assert_can_assign(val, SubclassValue(TypedValue(bool)))
+    assert_can_assign(val, SubclassValue(UNRESOLVED_VALUE))
+    assert_cannot_assign(val, SubclassValue(TypedValue(str)))
+    val = SubclassValue(TypedValue(str))
     assert_eq("Type[str]", str(val))
-    assert_is(str, val.typ)
+    assert_eq(TypedValue(str), val.typ)
     assert val.is_type(str)
     assert not val.is_type(int)
 

--- a/pyanalyze/test_value.py
+++ b/pyanalyze/test_value.py
@@ -173,7 +173,7 @@ def test_subclass_value() -> None:
     assert_can_assign(val, TypedValue(type))
     assert_cannot_assign(val, TypedValue(int))
     assert_can_assign(val, SubclassValue(TypedValue(bool)))
-    assert_can_assign(val, SubclassValue(UNRESOLVED_VALUE))
+    assert_can_assign(val, TypedValue(type))
     assert_cannot_assign(val, SubclassValue(TypedValue(str)))
     val = SubclassValue(TypedValue(str))
     assert_eq("Type[str]", str(val))

--- a/pyanalyze/test_value.py
+++ b/pyanalyze/test_value.py
@@ -13,6 +13,7 @@ from . import value
 from .arg_spec import ArgSpecCache
 from .test_config import TestConfig
 from .value import (
+    AnnotatedValue,
     Value,
     GenericValue,
     KnownValue,
@@ -376,6 +377,12 @@ def test_new_type_value() -> None:
     # This should eventually return False
     assert_can_assign(nt1_val, TypedValue(int))
     assert_can_assign(TypedValue(int), nt1_val)
+
+
+def test_annotated_value() -> None:
+    tv_int = TypedValue(int)
+    assert_can_assign(AnnotatedValue(tv_int, [tv_int]), tv_int)
+    assert_can_assign(tv_int, AnnotatedValue(tv_int, [tv_int]))
 
 
 def test_io() -> None:

--- a/pyanalyze/value.py
+++ b/pyanalyze/value.py
@@ -21,12 +21,14 @@ from typing import (
     Set,
     Tuple,
     Union,
+    Type,
     TypeVar,
 )
 
 from .safe import safe_isinstance
 from .type_object import TypeObject
 
+T = TypeVar("T")
 # __builtin__ in Python 2 and builtins in Python 3
 BUILTIN_MODULE = str.__module__
 KNOWN_MUTABLE_TYPES = (list, set, dict, deque)
@@ -766,6 +768,11 @@ class AnnotatedValue(Value):
         yield from self.value.walk_values()
         for val in self.metadata:
             yield from val.walk_values()
+
+    def get_metadata_of_type(self, typ: Type[T]) -> Iterable[T]:
+        for data in self.metadata:
+            if isinstance(data, KnownValue) and isinstance(data.val, typ):
+                yield typ
 
     def __str__(self) -> str:
         return f"Annotated[{self.value}, {', '.join(map(str, self.metadata))}]"

--- a/pyanalyze/value.py
+++ b/pyanalyze/value.py
@@ -753,10 +753,19 @@ class AnnotatedValue(Value):
         return self.value.get_type()
 
     def substitute_typevars(self, typevars: TypeVarMap) -> "Value":
-        return AnnotatedValue(self.value.substitute_typevars(typevars), self.metadata)
+        return AnnotatedValue(
+            self.value.substitute_typevars(typevars),
+            [value.substitute_typevars(typevars) for value in self.metadata],
+        )
 
     def can_assign(self, other: Value, ctx: CanAssignContext) -> Optional[TypeVarMap]:
         return self.value.can_assign(other, ctx)
+
+    def walk_values(self) -> Iterable[Value]:
+        yield self
+        yield from self.value.walk_values()
+        for val in self.metadata:
+            yield from val.walk_values()
 
     def __str__(self) -> str:
         return f"Annotated[{self.value}, {', '.join(map(str, self.metadata))}]"

--- a/pyanalyze/value.py
+++ b/pyanalyze/value.py
@@ -846,7 +846,9 @@ def unite_values(*values: Value) -> Value:
     for value in values:
         if isinstance(value, MultiValuedValue):
             subvals = value.vals
-        elif isinstance(value, AnnotatedValue) and isinstance(value.value, MultiValuedValue):
+        elif isinstance(value, AnnotatedValue) and isinstance(
+            value.value, MultiValuedValue
+        ):
             subvals = value.value.vals
         else:
             subvals = [value]


### PR DESCRIPTION
We keep Annotated around at runtime, which risks incomplete support but enables us to use Annotated types in the future.