### PR TITLE
Optimize MultiValuedValue.can_assign

### DIFF
--- a/pyanalyze/test_value.py
+++ b/pyanalyze/test_value.py
@@ -82,6 +82,8 @@ def test_known_value() -> None:
     assert_can_assign(val, MultiValuedValue([val, UNRESOLVED_VALUE]))
     assert_cannot_assign(val, MultiValuedValue([val, TypedValue(int)]))
     assert_cannot_assign(KnownValue(int), SubclassValue(TypedValue(int)))
+    assert_cannot_assign(KnownValue(1), KnownValue(True))
+    assert_cannot_assign(KnownValue(True), KnownValue(1))
 
 
 def test_unbound_method_value() -> None:
@@ -259,6 +261,14 @@ def test_multi_valued_value() -> None:
             [UNRESOLVED_VALUE, MultiValuedValue([TypedValue(int), KnownValue(None)])]
         ),
     )
+
+
+def test_large_union_optimization() -> None:
+    val = MultiValuedValue([*[KnownValue(i) for i in range(10000)], TypedValue(str)])
+    assert_can_assign(val, KnownValue(1))
+    assert_cannot_assign(val, KnownValue(234234))
+    assert_cannot_assign(val, KnownValue(True))
+    assert_can_assign(val, KnownValue(""))
 
 
 class ThriftEnum(object):

--- a/pyanalyze/value.py
+++ b/pyanalyze/value.py
@@ -889,6 +889,19 @@ class MultiValuedValue(Value):
         )
 
     def can_assign(self, other: Value, ctx: CanAssignContext) -> CanAssign:
+        if isinstance(other, KnownValue) and len(self.vals) > 50:
+            try:
+                my_values = {subval.val for subval in self.vals if isinstance(subval, KnownValue)}
+            except TypeError:
+                pass  # not hashable
+            else:
+                try:
+                    is_present = other.val in my_values
+                except TypeError:
+                    pass  # not hashable
+                else:
+                    if is_present:
+                        return {}
         if isinstance(other, MultiValuedValue):
             tv_maps = []
             for val in other.vals:

--- a/pyanalyze/value.py
+++ b/pyanalyze/value.py
@@ -903,8 +903,11 @@ class MultiValuedValue(Value):
         elif isinstance(other, AnnotatedValue):
             return self.can_assign(other.value, ctx)
         else:
-            # Optimization for large unions of literals
             my_vals = self.vals
+            # Optimization for large unions of literals. We could perhaps cache this set,
+            # but that's more complicated. Empirically this is already much faster.
+            # The number 20 is arbitrary. I noticed the bottleneck in production on a
+            # Union with nearly 500 values.
             if isinstance(other, KnownValue) and len(my_vals) > 20:
                 try:
                     # Include the type to avoid e.g. 1 and True matching


### PR DESCRIPTION
Fixes #157

This is a simpler solution than proposed in the issue, but empirically it already fixes the bottleneck.

This also fixes a bug where we'd allow KnownValues of different types that compare equal to intermix.