### PR TITLE
add documented code for AST annotation

### DIFF
--- a/pyanalyze/__init__.py
+++ b/pyanalyze/__init__.py
@@ -3,6 +3,7 @@
 pyanalyze is a package for Python static analysis.
 
 """
+from . import ast_annotator
 from . import name_check_visitor
 from . import analysis_lib
 from . import annotations
@@ -24,3 +25,5 @@ from . import typeshed
 from . import tests
 from . import value
 from . import yield_checker
+
+used(ast_annotator)

--- a/pyanalyze/analysis_lib.py
+++ b/pyanalyze/analysis_lib.py
@@ -5,7 +5,9 @@ Commonly useful components for static analysis tools.
 """
 import ast
 import os
-from typing import List, Callable, Optional, Set
+import sys
+import types
+from typing import List, Callable, Mapping, Optional, Set
 
 
 def _all_files(
@@ -80,3 +82,17 @@ def get_line_range_for_node(node: ast.AST, lines: List[str]) -> List[int]:
     ):
         last_lineno += 1
     return list(range(first_lineno, last_lineno))
+
+
+def make_module(
+    code_str: str, extra_scope: Mapping[str, object] = {}
+) -> types.ModuleType:
+    """Creates a Python module with the given code."""
+    module_name = "<test input>"
+    mod = types.ModuleType(module_name)
+    scope = mod.__dict__
+    scope["__name__"] = module_name
+    scope.update(extra_scope)
+    exec(code_str, scope)
+    sys.modules[module_name] = mod
+    return mod

--- a/pyanalyze/ast_annotator.py
+++ b/pyanalyze/ast_annotator.py
@@ -1,0 +1,158 @@
+"""
+
+Functionality for annotating the AST of a module.
+
+"""
+import ast
+import os
+import traceback
+import types
+from typing import Optional, Type, Union
+
+from .analysis_lib import make_module
+from .error_code import ErrorCode
+from .importer import load_module_from_file
+from .name_check_visitor import NameCheckVisitor, ClassAttributeChecker
+from .find_unused import used
+
+
+@used  # exposed as an API
+def annotate_code(
+    code: str,
+    *,
+    visitor_cls: Type[NameCheckVisitor] = NameCheckVisitor,
+    dump: bool = False,
+    show_errors: bool = False,
+    verbose: bool = False,
+) -> ast.Module:
+    """Annotate a piece of Python code. Return an AST with extra inferred_value attributes.
+
+    Example usage:
+
+        tree = annotate_code("a = 1")
+        print(tree.body[0].targets[0].inferred_value)  # Literal[1]
+
+    This will import and exec() the provided code. If this fails, the code will
+    still be annotated but the quality of the annotations will be much lower.
+
+    Optional arguments:
+        visitor_cls: pass a subclass of NameCheckVisitor to customize pyanalyze behavior
+        dump: if True, the annotated AST is printed out
+        show_errors: if True, errors from pyanalyze are printed
+        verbose: if True, more details are printed
+
+    """
+    tree = ast.parse(code)
+    try:
+        mod = make_module(code)
+    except Exception:
+        if verbose:
+            traceback.print_exc()
+        mod = None
+    _annotate_module("", mod, tree, code, visitor_cls, show_errors=show_errors)
+    if dump:
+        dump_annotated_code(tree)
+    return tree
+
+
+@used  # exposed as an API
+def annotate_file(
+    path: Union[str, os.PathLike[str]],
+    *,
+    visitor_cls: Type[NameCheckVisitor] = NameCheckVisitor,
+    verbose: bool = False,
+    dump: bool = False,
+    show_errors: bool = False,
+) -> ast.AST:
+    """Annotate the code in a Python source file. Return an AST with extra inferred_value attributes.
+
+    Example usage:
+
+        tree = annotate_file("/some/file.py")
+        print(tree.body[0].targets[0].inferred_value)  # Literal[1]
+
+    This will import and exec() the provided code. If this fails, the code will
+    still be annotated but the quality of the annotations will be much lower.
+
+    Optional arguments:
+        visitor_cls: pass a subclass of NameCheckVisitor to customize pyanalyze behavior
+        dump: if True, the annotated AST is printed out
+        show_errors: if True, errors from pyanalyze are printed
+        verbose: if True, more details are printed
+
+    """
+    filename = os.fspath(path)
+    try:
+        mod, _ = load_module_from_file(filename, verbose=verbose)
+    except Exception:
+        if verbose:
+            traceback.print_exc()
+        mod = None
+
+    with open(filename) as f:
+        code = f.read()
+    tree = ast.parse(code)
+    _annotate_module(filename, mod, tree, code, visitor_cls, show_errors=show_errors)
+    if dump:
+        dump_annotated_code(tree)
+    return tree
+
+
+def dump_annotated_code(
+    node: ast.AST, depth: int = 0, field_name: Optional[str] = None
+) -> None:
+    """Print an annotated AST in a readable format."""
+    line = type(node).__name__
+    if field_name is not None:
+        line = f"{field_name}: {line}"
+    if (
+        hasattr(node, "lineno")
+        and hasattr(node, "col_offset")
+        and node.lineno is not None
+        and node.col_offset is not None
+    ):
+        line = f"{line}(@{node.lineno}:{node.col_offset})"
+    print(" " * depth + line)
+    new_depth = depth + 2
+    if hasattr(node, "inferred_value"):
+        print(" " * new_depth + str(node.inferred_value))
+    for field_name, value in ast.iter_fields(node):
+        if isinstance(value, ast.AST):
+            dump_annotated_code(value, new_depth, field_name)
+        elif isinstance(value, list):
+            if not value:
+                continue
+            print(" " * new_depth + field_name)
+            for element in value:
+                if isinstance(element, ast.AST):
+                    dump_annotated_code(element, new_depth + 2)
+                else:
+                    print(" " * (new_depth + 2) + repr(element))
+        elif value is not None:
+            print(" " * new_depth + f"{field_name}: {value!r}")
+
+
+def _annotate_module(
+    filename: str,
+    module: Optional[types.ModuleType],
+    tree: ast.Module,
+    code_str: str,
+    visitor_cls: Type[NameCheckVisitor],
+    show_errors: bool = False,
+) -> None:
+    """Annotate the AST for a module with inferred values.
+
+    Takes the module objects, its AST tree, and its literal code. Modifies the AST object in place.
+
+    """
+    with ClassAttributeChecker(visitor_cls.config, enabled=True) as attribute_checker:
+        visitor = visitor_cls(
+            filename,
+            code_str,
+            tree,
+            module=module,
+            settings={error_code: show_errors for error_code in ErrorCode},
+            attribute_checker=attribute_checker,
+            annotate=True,
+        )
+        visitor.check(ignore_missing_module=True)

--- a/pyanalyze/ast_annotator.py
+++ b/pyanalyze/ast_annotator.py
@@ -57,7 +57,7 @@ def annotate_code(
 
 @used  # exposed as an API
 def annotate_file(
-    path: "Union[str, os.PathLike[str]]",
+    path: Union[str, "os.PathLike[str]"],
     *,
     visitor_cls: Type[NameCheckVisitor] = NameCheckVisitor,
     verbose: bool = False,

--- a/pyanalyze/ast_annotator.py
+++ b/pyanalyze/ast_annotator.py
@@ -57,7 +57,7 @@ def annotate_code(
 
 @used  # exposed as an API
 def annotate_file(
-    path: Union[str, os.PathLike[str]],
+    path: "Union[str, os.PathLike[str]]",
     *,
     visitor_cls: Type[NameCheckVisitor] = NameCheckVisitor,
     verbose: bool = False,

--- a/pyanalyze/name_check_visitor.py
+++ b/pyanalyze/name_check_visitor.py
@@ -811,7 +811,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor, CanAssignContext):
     def load_module(self, filename: str) -> Tuple[Optional[types.ModuleType], bool]:
         return importer.load_module_from_file(filename)
 
-    def check(self) -> List[node_visitor.Failure]:
+    def check(self, ignore_missing_module: bool = False) -> List[node_visitor.Failure]:
         """Runs the visitor on this module."""
         start_time = qcore.utime()
         try:
@@ -819,7 +819,9 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor, CanAssignContext):
                 # skip compiled (Cythonized) files because pyanalyze will misinterpret the
                 # AST in some cases (for example, if a function was cdefed)
                 return []
-            if self.module is None or self.tree is None:
+            if self.tree is None:
+                return self.all_failures
+            if self.module is None and not ignore_missing_module:
                 # If we could not import the module, other checks frequently fail.
                 return self.all_failures
             with qcore.override(self, "state", VisitorState.collect_names):
@@ -830,7 +832,11 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor, CanAssignContext):
             # leaving this check disabled by default for now.
             self.show_errors_for_unused_ignores(ErrorCode.unused_ignore)
             self.show_errors_for_bare_ignores(ErrorCode.bare_ignore)
-            if self.unused_finder is not None and not self.has_file_level_ignore():
+            if (
+                self.module is not None
+                and self.unused_finder is not None
+                and not self.has_file_level_ignore()
+            ):
                 self.unused_finder.record_module_visited(self.module)
         except node_visitor.VisitorError:
             raise
@@ -1794,7 +1800,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor, CanAssignContext):
             self._simulate_import(node)
 
     def _maybe_record_usages_from_import(self, node: ast.ImportFrom) -> None:
-        if self.unused_finder is None:
+        if self.unused_finder is None or self.module is None:
             return
         if self._is_unimportable_module(node):
             return
@@ -2756,24 +2762,27 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor, CanAssignContext):
         self, node: ast.AST
     ) -> Tuple[Value, AbstractConstraint]:
         if isinstance(node, ast.Compare):
-            return self.constraint_from_compare(node)
+            pair = self.constraint_from_compare(node)
         elif isinstance(node, (ast.Name, ast.Attribute, ast.Subscript)):
             composite = self.composite_from_node(node)
             if composite.varname is not None:
                 constraint = Constraint(
                     composite.varname, ConstraintType.is_truthy, True, None
                 )
-                return composite.value, constraint
+                pair = composite.value, constraint
             else:
-                return composite.value, NULL_CONSTRAINT
+                pair = composite.value, NULL_CONSTRAINT
         elif isinstance(node, ast.Call):
-            return self.constraint_from_call(node)
+            pair = self.constraint_from_call(node)
         elif isinstance(node, ast.UnaryOp):
-            return self.constraint_from_unary_op(node)
+            pair = self.constraint_from_unary_op(node)
         elif isinstance(node, ast.BoolOp):
-            return self.constraint_from_bool_op(node)
+            pair = self.constraint_from_bool_op(node)
         else:
-            return self.visit(node), NULL_CONSTRAINT
+            pair = self.visit(node), NULL_CONSTRAINT
+        if self.annotate:
+            node.inferred_value = pair[0]
+        return pair
 
     def visit_Break(self, node: ast.Break) -> None:
         self._set_name_in_scope(LEAVES_LOOP, node, UNRESOLVED_VALUE)
@@ -3147,6 +3156,9 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor, CanAssignContext):
             with qcore.override(
                 self, "being_assigned", value if is_final else expected_type
             ), self.yield_checker.check_yield_result_assignment(is_yield):
+                self.visit(node.target)
+        else:
+            with qcore.override(self, "being_assigned", expected_type):
                 self.visit(node.target)
         # TODO: Idea for what to do if there is no value:
         # - Scopes keep track of a map {name: expected type}
@@ -3588,19 +3600,22 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor, CanAssignContext):
 
     def composite_from_node(self, node: ast.AST) -> Composite:
         if isinstance(node, ast.Attribute):
-            return self.composite_from_attribute(node)
+            composite = self.composite_from_attribute(node)
         elif isinstance(node, ast.Name):
-            return self.composite_from_name(node)
+            composite = self.composite_from_name(node)
         elif isinstance(node, ast.Subscript):
-            return self.composite_from_subscript(node)
+            composite = self.composite_from_subscript(node)
         elif isinstance(node, ast.Index):
             # static analysis: ignore[undefined_attribute]
-            return self.composite_from_node(node.value)
+            composite = self.composite_from_node(node.value)
         elif isinstance(node, (ast.ExtSlice, ast.Slice)):
             # These don't have a .lineno attribute, which would otherwise cause trouble.
-            return Composite(self.visit(node), None, None)
+            composite = Composite(self.visit(node), None, None)
         else:
-            return Composite(self.visit(node), None, node)
+            composite = Composite(self.visit(node), None, node)
+        if self.annotate:
+            node.inferred_value = composite.value
+        return composite
 
     def varname_for_constraint(self, node: ast.AST) -> Optional[Varname]:
         """Given a node, returns a variable name that could be used in a local scope."""
@@ -3692,7 +3707,8 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor, CanAssignContext):
                     if self.current_function is not None
                     else self.module
                 )
-                self.collector.record_call(caller, callee_val)
+                if caller is not None:
+                    self.collector.record_call(caller, callee_val)
 
             arg_values = [arg.value for arg in args]
             kw_values = [(kw, composite.value) for kw, composite in keywords]
@@ -3958,7 +3974,8 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor, CanAssignContext):
             if inner is self.current_class:
                 return
 
-        self.unused_finder.record(module_or_class, attribute, self.module.__name__)
+        if self.module is not None:
+            self.unused_finder.record(module_or_class, attribute, self.module.__name__)
 
     @classmethod
     def _get_argument_parser(cls) -> ArgumentParser:

--- a/pyanalyze/test_ast_annotator.py
+++ b/pyanalyze/test_ast_annotator.py
@@ -46,7 +46,7 @@ x.a + 1
 def test_everything_annotated() -> None:
     pyanalyze_dir = Path(__file__).parent
     failures = []
-    for filename in files_with_extension_from_directory("py", pyanalyze_dir):
+    for filename in sorted(files_with_extension_from_directory("py", pyanalyze_dir)):
         tree = annotate_file(filename, show_errors=True)
         for node in ast.walk(tree):
             if isinstance(node, ast.expr) and not hasattr(node, "inferred_value"):

--- a/pyanalyze/test_ast_annotator.py
+++ b/pyanalyze/test_ast_annotator.py
@@ -47,7 +47,7 @@ def test_everything_annotated() -> None:
     pyanalyze_dir = Path(__file__).parent
     failures = []
     for filename in files_with_extension_from_directory("py", pyanalyze_dir):
-        tree = annotate_file(filename)
+        tree = annotate_file(filename, show_errors=True)
         for node in ast.walk(tree):
             if isinstance(node, ast.expr) and not hasattr(node, "inferred_value"):
                 failures.append((filename, node))

--- a/pyanalyze/test_ast_annotator.py
+++ b/pyanalyze/test_ast_annotator.py
@@ -50,9 +50,8 @@ def test_everything_annotated() -> None:
         tree = annotate_file(filename)
         for node in ast.walk(tree):
             if isinstance(node, ast.expr) and not hasattr(node, "inferred_value"):
-                print(filename, node)
                 failures.append((filename, node))
     if failures:
         for filename, node in failures:
-            print(f"{filename}: {ast.dump(node)}")
+            print(f"{filename}:{node.lineno}:{node.col_offset}: {ast.dump(node)}")
         assert False, f"found no annotations on {len(failures)} expressions"

--- a/pyanalyze/test_ast_annotator.py
+++ b/pyanalyze/test_ast_annotator.py
@@ -49,7 +49,11 @@ def test_everything_annotated() -> None:
     for filename in sorted(files_with_extension_from_directory("py", pyanalyze_dir)):
         tree = annotate_file(filename, show_errors=True)
         for node in ast.walk(tree):
-            if isinstance(node, ast.expr) and not hasattr(node, "inferred_value"):
+            if (
+                hasattr(node, "lineno")
+                and not hasattr(node, "inferred_value")
+                and not isinstance(node, (ast.keyword, ast.arg))
+            ):
                 failures.append((filename, node))
     if failures:
         for filename, node in failures:

--- a/pyanalyze/test_ast_annotator.py
+++ b/pyanalyze/test_ast_annotator.py
@@ -1,0 +1,58 @@
+import ast
+from pathlib import Path
+from typing import Type
+from qcore.asserts import assert_eq
+
+from .ast_annotator import annotate_file, annotate_code
+from .analysis_lib import files_with_extension_from_directory
+from .value import KnownValue, Value
+
+
+def _check_inferred_value(
+    tree: ast.Module, node_type: Type[ast.AST], value: Value
+) -> None:
+    for node in ast.walk(tree):
+        if isinstance(node, node_type):
+            assert hasattr(node, "inferred_value"), repr(node)
+            assert_eq(value, node.inferred_value, extra=ast.dump(node))
+
+
+def test_annotate_code() -> None:
+    tree = annotate_code("a = 1")
+    _check_inferred_value(tree, ast.Constant, KnownValue(1))
+    _check_inferred_value(tree, ast.Name, KnownValue(1))
+
+    tree = annotate_code(
+        """
+class X:
+    def __init__(self):
+        self.a = 1
+    """
+    )
+    _check_inferred_value(tree, ast.Attribute, KnownValue(1))
+    tree = annotate_code(
+        """
+class X:
+    def __init__(self):
+        self.a = 1
+
+x = X()
+x.a + 1
+    """
+    )
+    _check_inferred_value(tree, ast.BinOp, KnownValue(2))
+
+
+def test_everything_annotated() -> None:
+    pyanalyze_dir = Path(__file__).parent
+    failures = []
+    for filename in files_with_extension_from_directory("py", pyanalyze_dir):
+        tree = annotate_file(filename)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.expr) and not hasattr(node, "inferred_value"):
+                print(filename, node)
+                failures.append((filename, node))
+    if failures:
+        for filename, node in failures:
+            print(f"{filename}: {ast.dump(node)}")
+        assert False, f"found no annotations on {len(failures)} expressions"

--- a/pyanalyze/test_name_check_visitor.py
+++ b/pyanalyze/test_name_check_visitor.py
@@ -6,6 +6,7 @@ Tests for the test_scope.py script.
 """
 
 import ast
+from pyanalyze.analysis_lib import make_module
 from asynq import FutureBase, AsyncTask
 import collections
 import os
@@ -111,13 +112,10 @@ class TestAnnotatingNodeVisitor(test_node_visitor.BaseNodeVisitorTester):
         )
 
 
-def _make_module(code_str):
+def _make_module(code_str: str) -> types.ModuleType:
     """Creates a Python module with the given code."""
-    module_name = "<test input>"
-    mod = types.ModuleType(module_name)
-    scope = mod.__dict__
     # make helpers for value inference checking available to all tests
-    scope.update(
+    extra_scope = dict(
         assert_is_value=assert_is_value,
         AsyncTaskIncompleteValue=AsyncTaskIncompleteValue,
         DictIncompleteValue=DictIncompleteValue,
@@ -137,11 +135,8 @@ def _make_module(code_str):
         dump_value=dump_value,
         UNINITIALIZED_VALUE=UNINITIALIZED_VALUE,
         NO_RETURN_VALUE=NO_RETURN_VALUE,
-        __name__=module_name,
     )
-    exec(code_str, scope)
-    sys.modules[module_name] = mod
-    return mod
+    return make_module(code_str, extra_scope)
 
 
 # ===================================================

--- a/pyanalyze/test_name_check_visitor.py
+++ b/pyanalyze/test_name_check_visitor.py
@@ -2258,6 +2258,20 @@ class TestRequireAnnotations(TestNameCheckVisitorBase):
                 pass
 
 
+class TestAnnAssign(TestNameCheckVisitorBase):
+    @assert_passes()
+    def test(self):
+        from typing_extensions import Final
+
+        def capybara() -> None:
+            x: Final = 3
+            assert_is_value(x, KnownValue(3))
+            y: int = 3
+            assert_is_value(y, TypedValue(int))
+            z: float
+            print(z)  # E: undefined_name
+
+
 class HasGetattr(object):
     def __getattr__(self, attr):
         return 42

--- a/pyanalyze/typeshed.py
+++ b/pyanalyze/typeshed.py
@@ -21,7 +21,13 @@ from .value import (
 
 import ast
 import builtins
-from collections.abc import Awaitable, Collection, Set as AbstractSet, Sized
+from collections.abc import (
+    Awaitable,
+    Collection,
+    MutableMapping,
+    Set as AbstractSet,
+    Sized,
+)
 from contextlib import AbstractContextManager
 from dataclasses import dataclass
 import collections.abc
@@ -30,7 +36,6 @@ import inspect
 import sys
 from types import GeneratorType
 from typing import (
-    MutableMapping,
     cast,
     Any,
     Generic,

--- a/pyanalyze/typeshed.py
+++ b/pyanalyze/typeshed.py
@@ -347,6 +347,10 @@ class TypeshedFinder(object):
             if module == "_io":
                 module = "io"
             fq_name = ".".join([module, obj.__qualname__])
+            # Avoid looking for stubs we won't find anyway.
+            if any(not part.isidentifier() for part in fq_name.split(".")):
+                self.log("Ignoring non-identifier name", fq_name)
+                return None
             return _TYPING_ALIASES.get(fq_name, fq_name)
         except (AttributeError, TypeError):
             self.log("Ignoring object without module or qualname", obj)

--- a/pyanalyze/typeshed.py
+++ b/pyanalyze/typeshed.py
@@ -30,6 +30,7 @@ import inspect
 import sys
 from types import GeneratorType
 from typing import (
+    MutableMapping,
     cast,
     Any,
     Generic,
@@ -40,7 +41,7 @@ from typing import (
     List,
     TypeVar,
 )
-from typing_extensions import Protocol
+from typing_extensions import Protocol, TypedDict
 import typeshed_client
 from typed_ast import ast3
 
@@ -141,6 +142,8 @@ class TypeshedFinder(object):
             return [GenericValue(Generic, (TypeVarValue(T_co),))]
         if typ is Callable or typ is collections.abc.Callable:
             return None
+        if typ is TypedDict:
+            return [GenericValue(MutableMapping, [TypedValue(str), TypedValue(object)])]
         fq_name = self._get_fq_name(typ)
         if fq_name is None:
             return None


### PR DESCRIPTION
Fixes #166 

Plus some related changes:
- Make the importer fall back to importing outside sys.path (which seems generally useful)
- Make name_check_visitor.py work a bit better if self.module is None
- Ensure all expressions have an annotation set