### PR TITLE
Be less eager with setting NO_RETURN_VALUE

### DIFF
--- a/pyanalyze/name_check_visitor.py
+++ b/pyanalyze/name_check_visitor.py
@@ -879,9 +879,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor, CanAssignContext):
             ret = UNRESOLVED_VALUE
         finally:
             self.node_context.contexts.pop()
-        if ret is NO_RETURN_VALUE:
-            self._set_name_in_scope(LEAVES_SCOPE, node, UNRESOLVED_VALUE)
-        elif ret is None:
+        if ret is None:
             ret = UNRESOLVED_VALUE
         if self.annotate:
             node.inferred_value = ret
@@ -2947,8 +2945,6 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor, CanAssignContext):
                     self.visit(handler)
 
         return [try_scope] + except_scopes
-        self.scopes.combine_subscopes([try_scope] + except_scopes)
-        self.yield_checker.reset_yield_checks()
 
     def visit_Try(self, node: ast.Try) -> None:
         # py3 combines the Try and Try/Finally nodes
@@ -3840,6 +3836,9 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor, CanAssignContext):
                             error_code=ErrorCode.incompatible_call,
                         )
                     return_value = KnownValue(result)
+
+        if return_value is NO_RETURN_VALUE:
+            self._set_name_in_scope(LEAVES_SCOPE, node, UNRESOLVED_VALUE)
 
         # for .asynq functions, we use the argspec for the underlying function, but that means
         # that the return value is not wrapped in AsyncTask, so we do that manually here

--- a/pyanalyze/test_stacked_scopes.py
+++ b/pyanalyze/test_stacked_scopes.py
@@ -320,6 +320,18 @@ class TestTry(TestNameCheckVisitorBase):
             assert_is_value(x, KnownValue(4))
 
     @assert_passes()
+    def test_finally_regression():
+        import subprocess
+
+        def test_full():
+            clients = []
+            try:
+                clients.append(subprocess.Popen([]))
+            finally:
+                for client in clients:
+                    client.kill()
+
+    @assert_passes()
     def test_finally_plus_if(self):
         # here an approach that simply ignores the assignments in the try block while examining the
         # finally block would fail


### PR DESCRIPTION
Fixes a regression from #167 to #168. We sometimes infer the type of local variables as NO_RETURN_VALUE, but that can lead to spurious entries being added to the `%LEAVES_SCOPE` magical variable.