### PR TITLE
fix missing AnnotatedValue handling

### DIFF
--- a/pyanalyze/test_name_check_visitor.py
+++ b/pyanalyze/test_name_check_visitor.py
@@ -1637,6 +1637,15 @@ class TestSubscripting(TestNameCheckVisitorBase):
         def capybara():
             return [1, 2][3.0]
 
+    @assert_passes()
+    def test_weak():
+        from typing import Any, Dict, List
+
+        def get_min_max_pk_value(
+            min_pks: List[Dict[str, Any]], max_pks: List[Dict[str, Any]]
+        ):
+            return [r["pk"] for r in [*min_pks, *max_pks]]
+
 
 class TestPython3Compatibility(TestNameCheckVisitorBase):
     @assert_fails(ErrorCode.mixing_bytes_and_text)

--- a/pyanalyze/value.py
+++ b/pyanalyze/value.py
@@ -755,10 +755,7 @@ class CallableValue(TypedValue):
             if bound_method is not None:
                 signature = bound_method.get_signature()
         if signature is not None:
-            tv_map_or_error = self.signature.can_assign(signature, ctx)
-            if isinstance(tv_map_or_error, CanAssignError):
-                return tv_map_or_error
-            return tv_map_or_error
+            return self.signature.can_assign(signature, ctx)
 
         return super().can_assign(other, ctx)
 
@@ -1137,6 +1134,9 @@ class AnnotatedValue(Value):
 
     def get_type(self) -> Optional[type]:
         return self.value.get_type()
+
+    def get_type_value(self) -> Value:
+        return self.value.get_type_value()
 
     def substitute_typevars(self, typevars: TypeVarMap) -> Value:
         metadata = [val.substitute_typevars(typevars) for val in self.metadata]


### PR DESCRIPTION
Manifested itself as "too many positional arguments to dict.__getitem__"