### PR TITLE
use module-level __annotations__ for types

### DIFF
--- a/pyanalyze/implementation.py
+++ b/pyanalyze/implementation.py
@@ -2,7 +2,7 @@ from .annotations import type_from_value
 from .error_code import ErrorCode
 from .extensions import reveal_type
 from .format_strings import parse_format_string
-from .safe import safe_hasattr
+from .safe import safe_hasattr, safe_isinstance, safe_issubclass
 from .stacked_scopes import (
     NULL_CONSTRAINT,
     AbstractConstraint,
@@ -928,6 +928,25 @@ def get_default_argspecs() -> Dict[object, Signature]:
             ],
             impl=_issubclass_impl,
             callable=issubclass,
+        ),
+        Signature.make(
+            [SigParameter("obj"), SigParameter("class_or_tuple")],
+            impl=_isinstance_impl,
+            callable=safe_isinstance,
+        ),
+        Signature.make(
+            [
+                SigParameter("cls", _POS_ONLY, annotation=TypedValue(type)),
+                SigParameter(
+                    "class_or_tuple",
+                    _POS_ONLY,
+                    annotation=MultiValuedValue(
+                        [TypedValue(type), GenericValue(tuple, [TypedValue(type)])]
+                    ),
+                ),
+            ],
+            impl=_issubclass_impl,
+            callable=safe_issubclass,
         ),
         Signature.make(
             [

--- a/pyanalyze/name_check_visitor.py
+++ b/pyanalyze/name_check_visitor.py
@@ -53,7 +53,7 @@ import qcore
 from qcore.helpers import safe_str
 
 from . import attributes, format_strings, node_visitor, importer, method_return_type
-from .annotations import type_from_value, is_typing_name
+from .annotations import type_from_runtime, type_from_value, is_typing_name
 from .arg_spec import ArgSpecCache, is_dot_asynq_function
 from .config import Config
 from .error_code import ErrorCode, DISABLED_BY_DEFAULT, ERROR_DESCRIPTION
@@ -746,7 +746,8 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor, CanAssignContext):
             and not self.is_compiled
         ):
             self.attribute_checker.record_module_examined(self.module.__name__)
-        self.scopes = StackedScopes(self.module)
+
+        self.scopes = build_stacked_scopes(self.module)
         self.node_context = StackedContexts()
         self.asynq_checker = AsynqChecker(
             self.config,
@@ -4160,6 +4161,33 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor, CanAssignContext):
                 checker.types_with_dynamic_attrs
             )
             attribute_checker.filename_to_visitor.update(checker.filename_to_visitor)
+
+
+def build_stacked_scopes(module: Optional[types.ModuleType]) -> StackedScopes:
+    """Build a StackedScopes object.
+
+    Not part of stacked_scopes.py to avoid a circular dependency.
+
+    """
+    if module is None:
+        module_vars = {"__name__": TypedValue(str), "__file__": TypedValue(str)}
+    else:
+        module_vars = {key: KnownValue(value) for key, value in module.__dict__.items()}
+        module_vars = {}
+        annotations = getattr(module, "__annotations__", {})
+        for key, value in module.__dict__.items():
+            try:
+                annotation = annotations[key]
+            except Exception:
+                # Malformed __annotations__
+                val = KnownValue(value)
+            else:
+                if is_typing_name(annotation, "Final"):
+                    val = KnownValue(value)
+                else:
+                    val = type_from_runtime(annotation, globals=module.__dict__)
+            module_vars[key] = val
+    return StackedScopes(module_vars, module)
 
 
 def _get_task_cls(fn: Any) -> Any:

--- a/pyanalyze/safe.py
+++ b/pyanalyze/safe.py
@@ -35,16 +35,16 @@ def safe_equals(left: object, right: object) -> bool:
         return False
 
 
-def safe_issubclass(value: type, typ: Union[type, Tuple[type, ...]]) -> bool:
+def safe_issubclass(cls: type, class_or_tuple: Union[type, Tuple[type, ...]]) -> bool:
     try:
-        return issubclass(value, typ)
+        return issubclass(cls, class_or_tuple)
     except Exception:
         return False
 
 
-def safe_isinstance(value: object, typ: Union[type, Tuple[type, ...]]) -> bool:
+def safe_isinstance(obj: object, class_or_tuple: Union[type, Tuple[type, ...]]) -> bool:
     try:
-        return isinstance(value, typ)
+        return isinstance(obj, class_or_tuple)
     except Exception:
         return False
 

--- a/pyanalyze/stacked_scopes.py
+++ b/pyanalyze/stacked_scopes.py
@@ -955,13 +955,9 @@ class StackedScopes:
         None,
     )
 
-    def __init__(self, module: Optional[ModuleType]) -> None:
-        if module is None:
-            module_vars = {"__name__": TypedValue(str), "__file__": TypedValue(str)}
-        else:
-            module_vars = {
-                key: KnownValue(value) for key, value in module.__dict__.items()
-            }
+    def __init__(
+        self, module_vars: Dict[str, Value], module: Optional[ModuleType]
+    ) -> None:
         self.scopes = [
             self._builtin_scope,
             Scope(

--- a/pyanalyze/test_attributes.py
+++ b/pyanalyze/test_attributes.py
@@ -221,6 +221,23 @@ class TestAttributes(TestNameCheckVisitorBase):
             assert_is_value(E.no_name, KnownValue(E.no_name))
             assert_is_value(E.name, KnownValue(E.name))
 
+    @assert_passes()
+    def test_module_annotations(self):
+        from pyanalyze import value
+        from pyanalyze.type_object import TypeObject
+        from typing import Optional
+
+        annotated_global: Optional[str] = None
+
+        def capybara():
+            assert_is_value(
+                value._type_object_cache,
+                GenericValue(dict, [TypedValue(type), TypedValue(TypeObject)]),
+            )
+            assert_is_value(
+                annotated_global, MultiValuedValue([TypedValue(str), KnownValue(None)])
+            )
+
 
 class TestHasAttrExtension(TestNameCheckVisitorBase):
     @assert_passes()

--- a/pyanalyze/test_stacked_scopes.py
+++ b/pyanalyze/test_stacked_scopes.py
@@ -2,7 +2,8 @@
 from qcore.asserts import assert_eq, assert_in, assert_not_in, assert_is
 
 from .error_code import ErrorCode
-from .stacked_scopes import ScopeType, StackedScopes, uniq_chain
+from .name_check_visitor import build_stacked_scopes
+from .stacked_scopes import ScopeType, uniq_chain
 from .test_name_check_visitor import TestNameCheckVisitorBase
 from .test_node_visitor import assert_passes
 from .value import (
@@ -25,7 +26,7 @@ class Module(object):
 
 class TestStackedScopes(object):
     def setup(self):
-        self.scopes = StackedScopes(Module)
+        self.scopes = build_stacked_scopes(Module)
 
     def test_scope_type(self):
         assert_eq(ScopeType.module_scope, self.scopes.scope_type())


### PR DESCRIPTION
If a module has `__annotations__`, use those instead of the actual runtime type.