### PR TITLE
fix __bases__ bug

### DIFF
--- a/pyanalyze/arg_spec.py
+++ b/pyanalyze/arg_spec.py
@@ -260,13 +260,13 @@ class ArgSpecCache:
             ):
                 module = sys.modules[module_name]
                 *class_names, function_name = qualname.split(".")
-                class_obj: Any = module
+                class_obj = module
                 for class_name in class_names:
                     class_obj = getattr(class_obj, class_name, None)
                     if class_obj is None:
                         break
                 if (
-                    class_obj is not None
+                    isinstance(class_obj, type)
                     and inspect.getattr_static(class_obj, function_name, None)
                     is function_object
                 ):

--- a/pyanalyze/test_signature.py
+++ b/pyanalyze/test_signature.py
@@ -1,5 +1,6 @@
 # static analysis: ignore
 from collections.abc import Sequence
+from pyanalyze.implementation import assert_is_value
 from qcore.asserts import assert_eq
 
 from .value import (
@@ -556,6 +557,23 @@ class TestCalls(TestNameCheckVisitorBase):
     def test_undefined_kwargs(self):
         def fn():
             return fn(**x)
+
+    @assert_passes()
+    def test_set__name__(self):
+        import pyanalyze.tests
+
+        class A:
+            def __init__(self) -> None:
+                assert_is_value(self, TypedValue(A))
+
+        A.__name__ = "B"
+        A.__init__.__name__ = "B"
+
+        def capybara():
+            assert_is_value(A(), TypedValue(A))
+            assert_is_value(
+                pyanalyze.tests.WhatIsMyName(), TypedValue(pyanalyze.tests.WhatIsMyName)
+            )
 
 
 class TestTypeVar(TestNameCheckVisitorBase):

--- a/pyanalyze/tests.py
+++ b/pyanalyze/tests.py
@@ -189,3 +189,12 @@ class FixedMethodReturnType(object):
 class KeywordOnlyArguments(object):
     def __init__(self, *args, **kwargs):
         assert set(kwargs) <= {"kwonly_arg"}
+
+
+class WhatIsMyName:
+    def __init__(self):
+        pass
+
+
+WhatIsMyName.__name__ = "Capybara"
+WhatIsMyName.__init__.__name__ = "capybara"


### PR DESCRIPTION
Saw this in testing on a class that manually sets `__name__`. I wasn't able to reproduce
it in a pyanalyze unit test but added tests for some similar scenarios.