### PR TITLE
Remove redundant code from unused argument checker

### DIFF
--- a/pyanalyze/annotations.py
+++ b/pyanalyze/annotations.py
@@ -247,6 +247,12 @@ def _type_from_runtime(val: Any, ctx: Context) -> Value:
         else:
             args = val[1:]
         return _value_of_origin_args(origin, args, val, ctx)
+    elif GenericAlias is not None and isinstance(val, GenericAlias):
+        origin = get_origin(val)
+        args = get_args(val)
+        if origin is tuple and not args:
+            return SequenceIncompleteValue(tuple, [])
+        return _value_of_origin_args(origin, args, val, ctx)
     elif typing_inspect.is_literal_type(val):
         args = typing_inspect.get_args(val)
         if len(args) == 0:
@@ -283,12 +289,6 @@ def _type_from_runtime(val: Any, ctx: Context) -> Value:
         # InitVar instances aren't being created
         # static analysis: ignore[undefined_attribute]
         return type_from_runtime(val.type)
-    elif GenericAlias is not None and isinstance(val, GenericAlias):
-        origin = get_origin(val)
-        args = get_args(val)
-        if origin is tuple and not args:
-            return SequenceIncompleteValue(tuple, [])
-        return _value_of_origin_args(origin, args, val, ctx)
     elif is_instance_of_typing_name(val, "AnnotatedMeta"):
         # Annotated in 3.6's typing_extensions
         origin, metadata = val.__args__

--- a/pyanalyze/name_check_visitor.py
+++ b/pyanalyze/name_check_visitor.py
@@ -1542,7 +1542,6 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor, CanAssignContext):
     def _check_function_unused_vars(
         self,
         scope: FunctionScope,
-        args: Iterable[ast.AST],
         enclosing_statement: Optional[ast.stmt] = None,
     ) -> None:
         """Shows errors for any unused variables in the function."""
@@ -1552,17 +1551,13 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor, CanAssignContext):
         all_used_def_nodes = set(
             chain.from_iterable(scope.usage_to_definition_nodes.values())
         )
-        arg_nodes = set(args)
         all_unused_nodes = all_def_nodes - all_used_def_nodes
         for unused in all_unused_nodes:
-            # Ignore names not defined through a Name node (e.g., some function arguments)
+            # Ignore names not defined through a Name node (e.g., function arguments)
             if not isinstance(unused, ast.Name) or not self._is_write_ctx(unused.ctx):
                 continue
             # Ignore names that are meant to be ignored
             if unused.id.startswith("_"):
-                continue
-            # Ignore arguments
-            if unused in arg_nodes:
                 continue
             # Ignore names involved in global and similar declarations
             if unused.id in scope.accessed_from_special_nodes:
@@ -2026,7 +2021,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor, CanAssignContext):
                     ret = self._visit_comprehension_inner(node, typ, iterable_type)
             stmt = self.node_context.nearest_enclosing(ast.stmt)
             assert isinstance(stmt, ast.stmt)
-            self._check_function_unused_vars(scope, (), enclosing_statement=stmt)
+            self._check_function_unused_vars(scope, enclosing_statement=stmt)
         return ret
 
     def _visit_comprehension_inner(

--- a/pyanalyze/name_check_visitor.py
+++ b/pyanalyze/name_check_visitor.py
@@ -1540,9 +1540,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor, CanAssignContext):
             return unite_values(*return_values), has_return, self.is_generator
 
     def _check_function_unused_vars(
-        self,
-        scope: FunctionScope,
-        enclosing_statement: Optional[ast.stmt] = None,
+        self, scope: FunctionScope, enclosing_statement: Optional[ast.stmt] = None
     ) -> None:
         """Shows errors for any unused variables in the function."""
         all_def_nodes = set(

--- a/pyanalyze/name_check_visitor.py
+++ b/pyanalyze/name_check_visitor.py
@@ -1506,7 +1506,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor, CanAssignContext):
                 return_values = self.return_values
                 return_set = scope.get_local(LEAVES_SCOPE, None, self.state)
 
-            self._check_function_unused_vars(scope, args)
+            self._check_function_unused_vars(scope)
             return self._compute_return_type(node, name, return_values, return_set)
 
     def _compute_return_type(


### PR DESCRIPTION
In Python 3 all function arguments are created through `arg` nodes. This check was only necessary in Python 2.