### PR TITLE
Add --disable-all CLI flag and allow enabling/disabling specific checks when --*-all passed

### DIFF
--- a/pyanalyze/node_visitor.py
+++ b/pyanalyze/node_visitor.py
@@ -335,11 +335,11 @@ class BaseNodeVisitor(ast.NodeVisitor):
                 settings = {code: True for code in cls.error_code_enum}
             else:
                 settings = cls._get_default_settings()
-                if settings is not None:
-                    for setting in args.enable:
-                        settings[cls.error_code_enum[setting]] = True
-                    for setting in args.disable:
-                        settings[cls.error_code_enum[setting]] = False
+            if settings is not None:
+                for setting in args.enable:
+                    settings[cls.error_code_enum[setting]] = True
+                for setting in args.disable:
+                    settings[cls.error_code_enum[setting]] = False
             kwargs = {
                 key: value
                 for key, value in args.__dict__.items()
@@ -834,7 +834,7 @@ class BaseNodeVisitor(ast.NodeVisitor):
                 "--enable-all",
                 action="store_true",
                 default=False,
-                help="Enable all checks",
+                help="Enable all checks by default",
             )
             parser.add_argument(
                 "-e",

--- a/pyanalyze/node_visitor.py
+++ b/pyanalyze/node_visitor.py
@@ -333,6 +333,8 @@ class BaseNodeVisitor(ast.NodeVisitor):
         if cls.error_code_enum is not None:
             if args.enable_all:
                 settings = {code: True for code in cls.error_code_enum}
+            elif args.disable_all:
+                settings = {code: False for code in cls.error_code_enum}
             else:
                 settings = cls._get_default_settings()
             if settings is not None:
@@ -343,7 +345,7 @@ class BaseNodeVisitor(ast.NodeVisitor):
             kwargs = {
                 key: value
                 for key, value in args.__dict__.items()
-                if key not in {"enable_all", "enable", "disable"}
+                if key not in {"enable_all", "disable_all", "enable", "disable"}
             }
             kwargs["settings"] = settings
         else:
@@ -829,12 +831,19 @@ class BaseNodeVisitor(ast.NodeVisitor):
         )
 
         if cls.error_code_enum is not None:
-            parser.add_argument(
+            all_group = parser.add_mutually_exclusive_group()
+            all_group.add_argument(
                 "-a",
                 "--enable-all",
                 action="store_true",
                 default=False,
                 help="Enable all checks by default",
+            )
+            all_group.add_argument(
+                "--disable-all",
+                action="store_true",
+                default=False,
+                help="Disable all checks by default",
             )
             parser.add_argument(
                 "-e",


### PR DESCRIPTION
Fixes #211 

Allows checks to be disabled with `-d` when `--enable-all` is passed, to support a strict default-enabled/deny-list approach to checks. Furthermore, adds a new `--disable-all` flag to the CLI, which disables all checks except those enabled with `-e`, to support a default-disabled/allow-list approach.

There didn't appear to be an obvious one-letter equivalent (`-A` and `-a` were already taken, as was `-d`, and `-D` was potentially confusingly not parallel with `-a`. However, if you want me to add one, I certainly can.

I've manually tested this in a variety of cases locally, but I'm not sure what, if anything, should be done about tests. I couldn't find where CLI args were tested, so I'm not sure what the current approach is. And while I'm reasonably experienced with pytest and know just enough unittest/xUnit to be dangerous, I'm not really familiar with nose, considering it has been unmaintained since before I learned Python, haha. So I'd appreciate some guidance on this, thanks!