### PR TITLE
Default to the CWD and don't dump a traceback if no path specified

### DIFF
--- a/pyanalyze/node_visitor.py
+++ b/pyanalyze/node_visitor.py
@@ -760,7 +760,9 @@ class BaseNodeVisitor(ast.NodeVisitor):
             epilog=epilog,
             formatter_class=argparse.RawDescriptionHelpFormatter,
         )
-        parser.add_argument("files", nargs="*", help="Files or directories to check")
+        parser.add_argument(
+            "files", nargs="*", default=".", help="Files or directories to check"
+        )
         parser.add_argument(
             "-v", "--verbose", help="Print more information.", action="count"
         )


### PR DESCRIPTION
Sorry I didn't get this in for v0.3.0! If no path is specified on the command line, `pyanalyze` will default to checking the current working directory, like `flake8`, rather than erroring out and dumping a traceback. Tested with and without paths passed and by using the entrypoint and `python -m`.

Fixes #219 