### PR TITLE
Return non-zero if called from the CLI and an error occurs

### DIFF
--- a/pyanalyze/__main__.py
+++ b/pyanalyze/__main__.py
@@ -1,8 +1,10 @@
+import sys
+
 from pyanalyze.name_check_visitor import NameCheckVisitor
 
 
 def main() -> None:
-    NameCheckVisitor.main()
+    sys.exit(NameCheckVisitor.main())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #224 

Ensures that Pyanalyze exits non-zero (with the exit code returned by `NameCheckVistor.main()`) if called from the CLI and an error occurs. This makes it usable as a pre-commit hook and with CIs, and matches other linters where this behavior is standard.