### PR TITLE
change how TypeVar instantiation works

### DIFF
--- a/pyanalyze/test_signature.py
+++ b/pyanalyze/test_signature.py
@@ -625,7 +625,7 @@ class TestTypeVar(TestNameCheckVisitorBase):
             assert_is_value(x, MultiValuedValue([KnownValue(None), TypedValue(int)]))
             assert_is_value(assert_not_none(x), TypedValue(int))
 
-    @assert_fails(ErrorCode.incompatible_argument)
+    @assert_passes()
     def test_only_T(self):
         from typing import Generic, TypeVar
 
@@ -636,7 +636,7 @@ class TestTypeVar(TestNameCheckVisitorBase):
                 pass
 
         def capybara(x: Capybara[int]) -> None:
-            x.add_one("x")
+            x.add_one("x")  # E: incompatible_argument
 
     @assert_passes()
     def test_multi_typevar(self):
@@ -652,6 +652,7 @@ class TestTypeVar(TestNameCheckVisitorBase):
             assert_is_value(mktemp(), UNRESOLVED_VALUE)
             assert_is_value(mktemp(prefix="p"), KnownValue("p"))
             assert_is_value(mktemp(suffix="s"), KnownValue("s"))
+            assert_is_value(mktemp("p", "s"), KnownValue("p") | KnownValue("s"))
 
     @assert_passes()
     def test_generic_base(self):
@@ -690,12 +691,12 @@ class TestTypeVar(TestNameCheckVisitorBase):
             take_base(c)
 
     @skip_before((3, 10))
-    @assert_fails(ErrorCode.incompatible_argument)
+    @assert_passes()
     def test_typeshed(self):
         from typing import List
 
         def capybara(lst: List[int]) -> None:
-            lst.append("x")
+            lst.append("x")  # E: incompatible_argument
 
     @assert_passes()
     def test_generic_super(self):


### PR DESCRIPTION
Previously, we used a very simple algorithm for resolving TypeVars: the first assignment wins. Now, we instead unify all the values from different parameters, which is a more standard approach. But it turned out we were relying on the previous behavior in order to get correct behavior with methods on generic classes, where we really do want to believe what the first argument is telling us (if we're in a `list[int]` and we type check `lst.append("str")`, we should reject the call, not conclude that the value of the TypeVar is `int | "str"`). To do that, we introduce a new concept where `KnownValue` and `UnboundMethodValue` can remember typevars applied to them, so we can set them correctly when we create a signature from the value.