### PR TITLE
add concept of AnySource

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ Just knowing that a name has been defined doesn't tell what you can do with the 
 
 The following subclasses of `Value` exist:
 
-- `UnresolvedValue` (with a single instance, `UNRESOLVED_VALUE`), representing that the script knows nothing about the value a node can contain. For example, if a file contains only the function `def f(x): return x`, the name `x` will have `UNRESOLVED_VALUE` as its value within the function, because there is no information to determine what value it can contain.
+- `AnyValue`, representing that the script knows nothing about the value a node can contain. For example, if a file contains only the function `def f(x): return x`, the name `x` will have `UNRESOLVED_VALUE` as its value within the function, because there is no information to determine what value it can contain.
 - `KnownValue` represents a value for which the script knows the concrete Python value. If a file contains the line `x = 1` and no other assignments to `x`, `x` will contain `KnownValue(1)`.
 - `TypedValue` represents that the script knows the type but not the exact value. If the only assignment to `x` is a line `x = int(some_function())`, the script infers that `x` contains `TypedValue(int)`. More generally, the script infers any call to a class as resulting in an instance of that class. The type is also inferred for the `self` argument of methods, for comprehensions, for function arguments with type annotations, and in a few other cases. This class has several subtypes:
   - `NewTypeValue` corresponds to [`typing.NewType`](https://docs.python.org/3/library/typing.html#newtype); it indicates a distinct type that is identical to some other type at runtime. At Quora we use newtypes for helper types like `qtype.Uid`.
@@ -562,6 +562,7 @@ implements basic support for integers with a limited range:
 from dataclasses import dataclass
 from pyanalyze.extensions import CustomCheck
 from pyanalyze.value import (
+    AnyValue,
     flatten_values,
     CanAssign,
     CanAssignError,
@@ -620,7 +621,7 @@ class GreaterThan(CustomCheck):
                 return CanAssignError(
                     f"Value {value.val!r} is not greater than {self.value}"
                 )
-        elif value is UNRESOLVED_VALUE:
+        elif isinstance(value, AnyValue):
             # We let Any through.
             return {}
         else:

--- a/pyanalyze/annotations.py
+++ b/pyanalyze/annotations.py
@@ -60,6 +60,7 @@ from .find_unused import used
 from .signature import SigParameter, Signature
 from .value import (
     AnnotatedValue,
+    AnyValue,
     CallableValue,
     CustomCheckExtension,
     Extension,
@@ -538,8 +539,8 @@ def _type_from_value(value: Value, ctx: Context) -> Value:
                 )
             ctx.show_error(f"Unrecognized subscripted annotation: {root}")
             return UNRESOLVED_VALUE
-    elif value is UNRESOLVED_VALUE:
-        return UNRESOLVED_VALUE
+    elif isinstance(value, AnyValue):
+        return value
     else:
         ctx.show_error(f"Unrecognized annotation {value}")
         return UNRESOLVED_VALUE
@@ -790,7 +791,7 @@ def _value_of_origin_args(
             origin = extra_origin
         if args:
             args_vals = [_type_from_runtime(val, ctx) for val in args]
-            if all(val is UNRESOLVED_VALUE for val in args_vals):
+            if all(isinstance(val, AnyValue) for val in args_vals):
                 return _maybe_typed_value(origin, ctx)
             return GenericValue(origin, args_vals)
         else:

--- a/pyanalyze/attributes.py
+++ b/pyanalyze/attributes.py
@@ -20,6 +20,7 @@ from .signature import Signature, MaybeSignature
 from .stacked_scopes import Composite
 from .value import (
     AnnotatedValue,
+    AnyValue,
     CallableValue,
     HasAttrExtension,
     KnownValueWithTypeVars,
@@ -34,7 +35,6 @@ from .value import (
     SubclassValue,
     TypedValue,
     TypeVarValue,
-    VariableNameValue,
 )
 
 # these don't appear to be in the standard types module
@@ -105,20 +105,20 @@ def get_attribute(ctx: AttrContext) -> Value:
     elif isinstance(root_value, SubclassValue):
         if isinstance(root_value.typ, TypedValue):
             attribute_value = _get_attribute_from_subclass(root_value.typ.typ, ctx)
-        elif root_value.typ is UNRESOLVED_VALUE:
+        elif isinstance(root_value.typ, AnyValue):
             attribute_value = UNRESOLVED_VALUE
         else:
             attribute_value = _get_attribute_from_known(type, ctx)
     elif isinstance(root_value, UnboundMethodValue):
         attribute_value = _get_attribute_from_unbound(root_value, ctx)
-    elif root_value is UNRESOLVED_VALUE or isinstance(root_value, VariableNameValue):
+    elif isinstance(root_value, AnyValue):
         attribute_value = UNRESOLVED_VALUE
     elif isinstance(root_value, MultiValuedValue):
         raise TypeError("caller should unwrap MultiValuedValue")
     else:
         attribute_value = UNINITIALIZED_VALUE
     if (
-        attribute_value is UNRESOLVED_VALUE or attribute_value is UNINITIALIZED_VALUE
+        isinstance(attribute_value, AnyValue) or attribute_value is UNINITIALIZED_VALUE
     ) and isinstance(ctx.root_value, AnnotatedValue):
         for guard in ctx.root_value.get_metadata_of_type(HasAttrExtension):
             if guard.attribute_name == KnownValue(ctx.attr):

--- a/pyanalyze/format_strings.py
+++ b/pyanalyze/format_strings.py
@@ -28,6 +28,7 @@ from typing_extensions import Literal
 from .error_code import ErrorCode
 from .value import (
     AnnotatedValue,
+    AnyValue,
     KnownValue,
     DictIncompleteValue,
     SequenceIncompleteValue,
@@ -150,7 +151,8 @@ class ConversionSpecifier:
         """Produces any errors from passing the given object to this specifier."""
         if isinstance(arg, AnnotatedValue):
             arg = arg.value
-        if arg is UNRESOLVED_VALUE or isinstance(arg, MultiValuedValue):
+        # TODO: handle MultiValuedValue usefully
+        if isinstance(arg, AnyValue) or isinstance(arg, MultiValuedValue):
             return
         if self.conversion_type in _NUMERIC_CONVERSION_TYPES:
             # to deal with some code that sets global state to None and changes it later
@@ -346,10 +348,10 @@ class PercentFormatString:
             else:
                 # it's a tuple but we don't know what's in it, so assume it's ok
                 return
-        elif args is UNRESOLVED_VALUE:
+        elif isinstance(args, AnyValue):
             return
         elif isinstance(args, MultiValuedValue):
-            if any(v is UNRESOLVED_VALUE or v.is_type(tuple) for v in args.vals):
+            if any(isinstance(v, AnyValue) or v.is_type(tuple) for v in args.vals):
                 return
             else:
                 all_args = (args,)

--- a/pyanalyze/implementation.py
+++ b/pyanalyze/implementation.py
@@ -16,6 +16,7 @@ from .stacked_scopes import (
 from .signature import ANY_SIGNATURE, SigParameter, Signature, ImplReturn, CallContext
 from .value import (
     AnnotatedValue,
+    AnyValue,
     CallableValue,
     CanAssignError,
     HasAttrGuardExtension,
@@ -386,7 +387,7 @@ def _sequence_getitem_impl(ctx: CallContext, typ: type) -> ImplReturn:
             else:
                 ctx.show_error(f"Invalid {typ.__name__} key {key}")
                 return UNRESOLVED_VALUE
-        elif key is UNRESOLVED_VALUE or isinstance(key, VariableNameValue):
+        elif isinstance(key, AnyValue):
             return UNRESOLVED_VALUE
         else:
             ctx.show_error(f"Invalid {typ.__name__} key {key}")

--- a/pyanalyze/implementation.py
+++ b/pyanalyze/implementation.py
@@ -35,7 +35,6 @@ from .value import (
     NO_RETURN_VALUE,
     KNOWN_MUTABLE_TYPES,
     Value,
-    VariableNameValue,
     WeakExtension,
     make_weak,
     unite_values,

--- a/pyanalyze/stacked_scopes.py
+++ b/pyanalyze/stacked_scopes.py
@@ -49,6 +49,7 @@ from .extensions import reveal_type
 from .safe import safe_equals, safe_issubclass
 from .value import (
     AnnotatedValue,
+    AnyValue,
     KnownValue,
     ReferencingValue,
     SubclassValue,
@@ -267,11 +268,11 @@ class Constraint(AbstractConstraint):
             yield UNINITIALIZED_VALUE
             return
         if self.constraint_type == ConstraintType.is_instance:
-            if inner_value is UNRESOLVED_VALUE:
+            if isinstance(inner_value, AnyValue):
                 if self.positive:
                     yield TypedValue(self.value)
                 else:
-                    yield UNRESOLVED_VALUE
+                    yield inner_value
             elif isinstance(inner_value, KnownValue):
                 if self.positive:
                     if isinstance(inner_value.val, self.value):
@@ -304,7 +305,7 @@ class Constraint(AbstractConstraint):
         elif self.constraint_type == ConstraintType.is_value:
             if self.positive:
                 known_val = KnownValue(self.value)
-                if inner_value is UNRESOLVED_VALUE:
+                if isinstance(inner_value, AnyValue):
                     yield known_val
                 elif isinstance(inner_value, KnownValue):
                     if inner_value.val is self.value:
@@ -569,7 +570,7 @@ class Scope:
     ) -> None:
         if varname not in self:
             self.variables[varname] = value
-        elif value is UNRESOLVED_VALUE or not safe_equals(
+        elif isinstance(value, AnyValue) or not safe_equals(
             self.variables[varname], value
         ):
             existing = self.variables[varname]

--- a/pyanalyze/test_annotations.py
+++ b/pyanalyze/test_annotations.py
@@ -5,6 +5,7 @@ from .implementation import assert_is_value
 from .error_code import ErrorCode
 from .value import (
     AnnotatedValue,
+    AnyValue,
     KnownValue,
     MultiValuedValue,
     NewTypeValue,
@@ -1018,7 +1019,7 @@ class TestCustomCheck(TestNameCheckVisitorBase):
                         return CanAssignError(
                             f"Value {value.val!r} is not greater than {self.value}"
                         )
-                elif value is UNRESOLVED_VALUE:
+                elif isinstance(value, AnyValue):
                     return {}
                 else:
                     return CanAssignError(f"Size of {value} is not known")

--- a/pyanalyze/test_name_check_visitor.py
+++ b/pyanalyze/test_name_check_visitor.py
@@ -28,6 +28,7 @@ from .stacked_scopes import Composite
 from .test_config import TestConfig
 from .value import (
     AnnotatedValue,
+    AnyValue,
     AsyncTaskIncompleteValue,
     CallableValue,
     DictIncompleteValue,
@@ -131,6 +132,7 @@ def _make_module(code_str: str) -> types.ModuleType:
         SequenceIncompleteValue=SequenceIncompleteValue,
         TypedValue=TypedValue,
         UnboundMethodValue=UnboundMethodValue,
+        AnyValue=AnyValue,
         UNRESOLVED_VALUE=UNRESOLVED_VALUE,
         VariableNameValue=VariableNameValue,
         ReferencingValue=ReferencingValue,

--- a/pyanalyze/typeshed.py
+++ b/pyanalyze/typeshed.py
@@ -9,6 +9,7 @@ from .error_code import ErrorCode
 from .stacked_scopes import uniq_chain
 from .signature import SigParameter, Signature
 from .value import (
+    AnyValue,
     TypedValue,
     GenericValue,
     KnownValue,
@@ -517,7 +518,7 @@ class TypeshedFinder(object):
         val = self._parse_expr(node, module)
         ctx = _AnnotationContext(finder=self, module=module)
         typ = type_from_value(val, ctx=ctx)
-        if self.verbose and typ is UNRESOLVED_VALUE:
+        if self.verbose and isinstance(typ, AnyValue):
             self.log("Got UNRESOLVED_VALUE", (ast3.dump(node), module))
         return typ
 


### PR DESCRIPTION
I'd been thinking of doing this for longer, but now I have a motivating use case. A CustomCheck that excludes Any may still want to allow one specific unavoidable kind of Any: the type of the element of an empty list. To support that, we replace the singleton `UNRESOLVED_VALUE` with instances of a new class `AnyValue` that provides a `source`.

This PR merely creates the enum and replaces `is UNRESOLVED_VALUE` checks within pyanalyze. After I migrate some internal code, I will replace usages of UNRESOLVED_VALUE within pyanalyze.