### PR TITLE
Don't throw away the return value for args/kwargs calls

### DIFF
--- a/pyanalyze/node_visitor.py
+++ b/pyanalyze/node_visitor.py
@@ -697,15 +697,16 @@ class BaseNodeVisitor(ast.NodeVisitor):
         return all_failures
 
     @classmethod
-    def _check_file_single_arg(cls, args: Tuple[str, Dict[str, Any]]) -> List[Failure]:
+    def _check_file_single_arg(
+        cls, args: Tuple[str, Dict[str, Any]]
+    ) -> Tuple[List[Failure], Any]:
         filename, kwargs = args
         main_module = sys.modules["__main__"]
         try:
-            failures, _ = cls.check_file_in_worker(filename, **kwargs)
+            return cls.check_file_in_worker(filename, **kwargs)
         finally:
             # Some modules cause __main__ to get reassigned for unclear reasons. So let's put it back.
             sys.modules["__main__"] = main_module
-        return failures
 
     @classmethod
     def check_file_in_worker(

--- a/pyanalyze/node_visitor.py
+++ b/pyanalyze/node_visitor.py
@@ -424,7 +424,7 @@ class BaseNodeVisitor(ast.NodeVisitor):
         changes = collections.defaultdict(list)
         with qcore.override(cls, "_changes_for_fixer", changes):
             try:
-                had_failure = cls._run(**kwargs)
+                had_failure = bool(cls._run(**kwargs))
             except VisitorError:
                 had_failure = True
         # ignore run_fixer if autofix is enabled
@@ -701,10 +701,11 @@ class BaseNodeVisitor(ast.NodeVisitor):
         filename, kwargs = args
         main_module = sys.modules["__main__"]
         try:
-            return cls.check_file_in_worker(filename, **kwargs)
+            failures, _ = cls.check_file_in_worker(filename, **kwargs)
         finally:
             # Some modules cause __main__ to get reassigned for unclear reasons. So let's put it back.
             sys.modules["__main__"] = main_module
+        return failures
 
     @classmethod
     def check_file_in_worker(


### PR DESCRIPTION
Another step towards *args/**kwargs type checking. Also found two issues within pyanalyze itself.