### PR TITLE
Infer precise types for comprehensions over known iterables

### DIFF
--- a/README.md
+++ b/README.md
@@ -680,6 +680,7 @@ The code is formatted using [Black](https://github.com/psf/black).
 
 Unreleased
 
+- Infer more precise types for comprehensions over known iterables (#279)
 - Add impl function for `list.__iadd__` (`+=`) (#280)
 - Simplify some overly complex types to improve performance (#280)
 - Detect usage of implicitly reexported names (#271)

--- a/pyanalyze/config.py
+++ b/pyanalyze/config.py
@@ -168,6 +168,10 @@ class Config(object):
     ASYNQ_DECORATORS = {asynq.asynq}
     ASYNC_PROXY_DECORATORS = {asynq.async_proxy}
 
+    # If we iterate over something longer than this, we don't try to infer precise
+    # types for comprehensions. Increasing this can hurt performance.
+    COMPREHENSION_LENGTH_INFERENCE_LIMIT = 25
+
     #
     # Used for VariableNameValue
     #

--- a/pyanalyze/name_check_visitor.py
+++ b/pyanalyze/name_check_visitor.py
@@ -2370,7 +2370,7 @@ class NameCheckVisitor(
                     GenericValue(
                         typ,
                         [
-                            unite_values(
+                            unite_and_simplify(
                                 *values, limit=self.config.UNION_SIMPLIFICATION_LIMIT
                             )
                         ],

--- a/pyanalyze/name_check_visitor.py
+++ b/pyanalyze/name_check_visitor.py
@@ -2011,6 +2011,8 @@ class NameCheckVisitor(
         if iterable_type is None:
             is_async = bool(node.is_async)
             iterable_type = self._member_value_of_iterator(node.iter, is_async)
+            if not isinstance(iterable_type, Value):
+                iterable_type = unite_values(*iterable_type)
         with qcore.override(self, "in_comprehension_body", True):
             with qcore.override(self, "being_assigned", iterable_type):
                 self.visit(node.target)

--- a/pyanalyze/name_check_visitor.py
+++ b/pyanalyze/name_check_visitor.py
@@ -2066,7 +2066,8 @@ class NameCheckVisitor(
             if (
                 len(node.generators) == 1
                 and not node.generators[0].ifs
-                and len(iterable_type)
+                and 0
+                < len(iterable_type)
                 <= self.config.COMPREHENSION_LENGTH_INFERENCE_LIMIT
             ):
                 generator = node.generators[0]

--- a/pyanalyze/test_implementation.py
+++ b/pyanalyze/test_implementation.py
@@ -179,7 +179,10 @@ class TestSuperCall(TestNameCheckVisitorBase):
 class TestSequenceImpl(TestNameCheckVisitorBase):
     @assert_passes()
     def test(self):
-        def capybara(x):
+        from typing import Sequence
+        from typing_extensions import Literal
+
+        def capybara(x, ints: Sequence[Literal[1, 2]]):
             # no arguments
             assert_is_value(set(), KnownValue(set()))
             assert_is_value(list(), KnownValue([]))
@@ -189,10 +192,8 @@ class TestSequenceImpl(TestNameCheckVisitorBase):
 
             # Comprehensions
             one_two = MultiValuedValue([KnownValue(1), KnownValue(2)])
-            assert_is_value(tuple(i for i in (1, 2)), GenericValue(tuple, [one_two]))
-            assert_is_value(
-                tuple({i: i for i in (1, 2)}), GenericValue(tuple, [one_two])
-            )
+            assert_is_value(tuple(i for i in ints), GenericValue(tuple, [one_two]))
+            assert_is_value(tuple({i: i for i in ints}), GenericValue(tuple, [one_two]))
 
             # SequenceIncompleteValue
             assert_is_value(
@@ -600,9 +601,9 @@ class TestGenericMutators(TestNameCheckVisitorBase):
     def test_list_extend_union(self):
         def capybara(cond):
             if cond:
-                lst = [1 for _ in range(3)]
+                lst = [1 for _ in cond]
             else:
-                lst = [2 for _ in range(3)]
+                lst = [2 for _ in cond]
             assert_is_value(
                 lst,
                 MultiValuedValue(

--- a/pyanalyze/test_name_check_visitor.py
+++ b/pyanalyze/test_name_check_visitor.py
@@ -1365,6 +1365,10 @@ class TestIterationTarget(TestNameCheckVisitorBase):
                 lst2, SequenceIncompleteValue(list, [KnownValue(1), KnownValue(2)])
             )
 
+            lst3 = [i + j * 10 for i in range(2) for j in range(3)]
+            # TODO: should be list[int] instead
+            assert_is_value(lst3, TypedValue(list))
+
     @assert_passes()
     def test_dict_comprehension(self):
         from typing_extensions import Literal


### PR DESCRIPTION
For example, we'll now infer `[x for x in (1, 2)]` as `SequenceIncompleteValue(list, [KnownValue(1), KnownValue(2)])`. I expect this to help with some edge cases from #275.