### PR TITLE
Add mismatched parameter name

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Show an error when a parameter may be passed a value with the wrong name (#340)
 - Correct location of error for incompatible parameter (#339)
 
 ## Version 0.5.0 (December 12, 2021)

--- a/pyanalyze/error_code.py
+++ b/pyanalyze/error_code.py
@@ -84,6 +84,7 @@ class ErrorCode(enum.Enum):
     missing_return = 67
     no_return_may_return = 68
     implicit_reexport = 69
+    mismatched_parameter_name = 70
 
 
 # Allow testing unannotated functions without too much fuss
@@ -191,6 +192,9 @@ ERROR_DESCRIPTION = {
     ErrorCode.missing_return: "Function may exit without returning a value",
     ErrorCode.no_return_may_return: "Function is annotated as NoReturn but may return",
     ErrorCode.implicit_reexport: "Use of implicitly re-exported name",
+    ErrorCode.mismatched_parameter_name: (
+        "Passing a parameter that may be passed to the wrong name"
+    ),
 }
 
 

--- a/pyanalyze/test_signature.py
+++ b/pyanalyze/test_signature.py
@@ -838,6 +838,31 @@ class TestCalls(TestNameCheckVisitorBase):
             kwonly(**bad_td)  # E: incompatible_call
 
 
+class TestMismatchedParameterName(TestNameCheckVisitorBase):
+    @assert_passes()
+    def test(self):
+        from dataclasses import dataclass
+
+        def f(a, b=None):
+            pass
+
+        @dataclass
+        class HasAB:
+            a: int = 0
+            b: int = 0
+
+        def capybara():
+            b = 3
+            a = 3
+            f(a, b)  # ok
+            f(b)  # E: mismatched_parameter_name
+            f(a, a)  # E: mismatched_parameter_name
+            obj = HasAB()
+            f(obj.b)  # E: mismatched_parameter_name
+            d = {"a": 1, "b": 2}
+            f(d["b"])  # E: mismatched_parameter_name
+
+
 class TestTypeVar(TestNameCheckVisitorBase):
     @assert_passes()
     def test_simple(self):


### PR DESCRIPTION
Generates a lot of false positives in pyanalyze's own tests, but I want to try it out on our internal codebase before adjusting the heuristics.