### PR TITLE
Put constraints in Annotated metadata

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Allow storing type narrowing constraints in variables (#343)
 - The first argument to `__new__` and `__init_subclass`
   does not need to be `self` (#342)
 - Drop dependencies on `attrs` and `mypy_extensions` (#341)

--- a/pyanalyze/annotations.py
+++ b/pyanalyze/annotations.py
@@ -647,11 +647,12 @@ class _DefaultContext(Context):
 
     def get_name(self, node: ast.Name) -> Value:
         if self.visitor is not None:
-            return self.visitor.resolve_name(
+            val, _ = self.visitor.resolve_name(
                 node,
                 error_node=self.node,
                 suppress_errors=self.should_suppress_undefined_names,
             )
+            return val
         elif self.globals is not None:
             if node.id in self.globals:
                 return KnownValue(self.globals[node.id])

--- a/pyanalyze/implementation.py
+++ b/pyanalyze/implementation.py
@@ -12,6 +12,7 @@ from .stacked_scopes import (
     PredicateProvider,
     OrConstraint,
     Varname,
+    VarnameWithOrigin,
 )
 from .signature import ANY_SIGNATURE, SigParameter, Signature, ImplReturn, CallContext
 from .value import (
@@ -115,7 +116,7 @@ def _isinstance_impl(ctx: CallContext) -> ImplReturn:
 
 
 def _constraint_from_isinstance(
-    varname: Optional[Varname], class_or_tuple: Value
+    varname: Optional[VarnameWithOrigin], class_or_tuple: Value
 ) -> AbstractConstraint:
     if varname is None:
         return NULL_CONSTRAINT

--- a/pyanalyze/implementation.py
+++ b/pyanalyze/implementation.py
@@ -544,9 +544,12 @@ def _dict_setdefault_impl(ctx: CallContext) -> ImplReturn:
             self_value.typ,
             [*self_value.kv_pairs, KVPair(key, default, is_required=not is_present)],
         )
-        no_return_unless = Constraint(
-            varname, ConstraintType.is_value_object, True, new_value
-        )
+        if varname is not None:
+            no_return_unless = Constraint(
+                varname, ConstraintType.is_value_object, True, new_value
+            )
+        else:
+            no_return_unless = NULL_CONSTRAINT
         if not is_present:
             return ImplReturn(default, no_return_unless=no_return_unless)
         return ImplReturn(
@@ -561,9 +564,12 @@ def _dict_setdefault_impl(ctx: CallContext) -> ImplReturn:
             new_type = make_weak(
                 GenericValue(self_value.typ, [new_key_type, new_value_type])
             )
-            no_return_unless = Constraint(
-                varname, ConstraintType.is_value_object, True, new_type
-            )
+            if varname is not None:
+                no_return_unless = Constraint(
+                    varname, ConstraintType.is_value_object, True, new_type
+                )
+            else:
+                no_return_unless = NULL_CONSTRAINT
             return ImplReturn(new_value_type, no_return_unless=no_return_unless)
         else:
             tv_map = key_type.can_assign(key, ctx.visitor)

--- a/pyanalyze/name_check_visitor.py
+++ b/pyanalyze/name_check_visitor.py
@@ -2496,7 +2496,9 @@ class NameCheckVisitor(
             out_constraints.append(constraint)
         constraint_cls = AndConstraint if is_and else OrConstraint
         constraint = constraint_cls.make(reversed(out_constraints))
-        return annotate_with_constraint(unite_values(*values), constraint)
+        return annotate_with_constraint(
+            unite_values(*values, default=AnyValue(AnySource.unreachable)), constraint
+        )
 
     def visit_Compare(self, node: ast.Compare) -> Value:
         if len(node.ops) != 1:

--- a/pyanalyze/name_check_visitor.py
+++ b/pyanalyze/name_check_visitor.py
@@ -2490,9 +2490,7 @@ class NameCheckVisitor(
             out_constraints.append(constraint)
         constraint_cls = AndConstraint if is_and else OrConstraint
         constraint = constraint_cls.make(reversed(out_constraints))
-        return annotate_with_constraint(
-            unite_values(*values, default=AnyValue(AnySource.unreachable)), constraint
-        )
+        return annotate_with_constraint(unite_values(*values), constraint)
 
     def visit_Compare(self, node: ast.Compare) -> Value:
         if len(node.ops) != 1:

--- a/pyanalyze/name_check_visitor.py
+++ b/pyanalyze/name_check_visitor.py
@@ -3105,7 +3105,9 @@ class NameCheckVisitor(
         self._handle_loop_else(node.orelse, body_scope, always_entered)
 
         if self.state == VisitorState.collect_names:
-            self.visit(node.test)
+            test, constraint = self.constraint_from_condition(
+                node.test, check_boolability=False
+            )
             with self.scopes.subscope():
                 self.add_constraint((node, 2), constraint)
                 self._generic_visit_list(node.body)

--- a/pyanalyze/name_check_visitor.py
+++ b/pyanalyze/name_check_visitor.py
@@ -3057,7 +3057,7 @@ class NameCheckVisitor(
         else:
             always_entered = len(iterated_value) > 0
         if not isinstance(iterated_value, Value):
-            iterated_value = unite_values(
+            iterated_value = unite_and_simplify(
                 *iterated_value, limit=self.config.UNION_SIMPLIFICATION_LIMIT
             )
         with self.scopes.subscope() as body_scope:

--- a/pyanalyze/name_check_visitor.py
+++ b/pyanalyze/name_check_visitor.py
@@ -2451,16 +2451,10 @@ class NameCheckVisitor(
                 else:
                     values.append(elt)
             if has_unknown_value:
-                return make_weak(
-                    GenericValue(
-                        typ,
-                        [
-                            unite_and_simplify(
-                                *values, limit=self.config.UNION_SIMPLIFICATION_LIMIT
-                            )
-                        ],
-                    )
+                arg = unite_and_simplify(
+                    *values, limit=self.config.UNION_SIMPLIFICATION_LIMIT
                 )
+                return make_weak(GenericValue(typ, [arg]))
             else:
                 return SequenceIncompleteValue(typ, values)
 
@@ -3063,7 +3057,9 @@ class NameCheckVisitor(
         else:
             always_entered = len(iterated_value) > 0
         if not isinstance(iterated_value, Value):
-            iterated_value = unite_values(*iterated_value)
+            iterated_value = unite_values(
+                *iterated_value, limit=self.config.UNION_SIMPLIFICATION_LIMIT
+            )
         with self.scopes.subscope() as body_scope:
             with self.scopes.loop_scope():
                 with qcore.override(self, "being_assigned", iterated_value):

--- a/pyanalyze/signature.py
+++ b/pyanalyze/signature.py
@@ -6,7 +6,6 @@ calls.
 
 """
 
-from .extensions import reveal_type
 from .error_code import ErrorCode
 from .safe import all_of_type
 from .stacked_scopes import (
@@ -17,7 +16,7 @@ from .stacked_scopes import (
     ConstraintType,
     NULL_CONSTRAINT,
     AbstractConstraint,
-    Varname,
+    VarnameWithOrigin,
 )
 from .value import (
     AnnotatedValue,
@@ -181,7 +180,7 @@ class CallContext:
             return composite.node
         return None
 
-    def varname_for_arg(self, arg: str) -> Optional[Varname]:
+    def varname_for_arg(self, arg: str) -> Optional[VarnameWithOrigin]:
         """Return a :term:`varname` corresponding to the given function argument.
 
         This is useful for creating a :class:`pyanalyze.stacked_scopes.Constraint`

--- a/pyanalyze/stacked_scopes.py
+++ b/pyanalyze/stacked_scopes.py
@@ -50,6 +50,7 @@ from .boolability import get_boolability
 from .extensions import reveal_type
 from .safe import safe_equals, safe_issubclass
 from .value import (
+    NO_RETURN_VALUE,
     AnnotatedValue,
     AnySource,
     AnyValue,
@@ -1168,6 +1169,9 @@ class FunctionScope(Scope):
             key = replace(ctx, fallback_value=None)
             if key in val.resolution_cache:
                 return val.resolution_cache[key]
+            # Guard against recursion. This happens in the test_len_condition test.
+            # Perhaps we should do something smarter to prevent recursion.
+            val.resolution_cache[key] = NO_RETURN_VALUE
             if val.definition_nodes or ctx.fallback_value:
                 resolved = self._get_value_from_nodes(
                     val.definition_nodes, ctx, val.constraints

--- a/pyanalyze/stacked_scopes.py
+++ b/pyanalyze/stacked_scopes.py
@@ -977,6 +977,9 @@ class FunctionScope(Scope):
             seen.add(definer)
             if definer is None:
                 out.add(None)
+            elif definer not in self.definition_node_to_value:
+                # maybe from a different scope
+                return EMPTY_ORIGIN
             else:
                 val = self.definition_node_to_value[definer]
                 if isinstance(val, _ConstrainedValue):

--- a/pyanalyze/stacked_scopes.py
+++ b/pyanalyze/stacked_scopes.py
@@ -1434,11 +1434,11 @@ def _constrain_value(
         values = list(flatten_values(fallback_value))
     for constraint in constraints:
         values = list(constraint.apply_to_values(values))
+    if not values:
+        return AnyValue(AnySource.unreachable)
     if simplification_limit is not None:
-        return unite_and_simplify(
-            *values, limit=simplification_limit, default=AnyValue(AnySource.unreachable)
-        )
-    return unite_values(*values, default=AnyValue(AnySource.unreachable))
+        return unite_and_simplify(*values, limit=simplification_limit)
+    return unite_values(*values)
 
 
 def annotate_with_constraint(value: Value, constraint: AbstractConstraint) -> Value:

--- a/pyanalyze/stacked_scopes.py
+++ b/pyanalyze/stacked_scopes.py
@@ -978,14 +978,6 @@ class FunctionScope(Scope):
             current_set = self._resolve_origin(current_origin)
             constraint_set = self._resolve_origin(constraint_origin)
             if current_set - constraint_set:
-                print(
-                    "REJECT CONSTRAINT",
-                    parent_varname,
-                    current_set,
-                    constraint_set,
-                    node,
-                    state,
-                )
                 return
 
         varname = constraint.varname.get_varname()

--- a/pyanalyze/stacked_scopes.py
+++ b/pyanalyze/stacked_scopes.py
@@ -946,14 +946,6 @@ class FunctionScope(Scope):
             current_set = self._resolve_origin(current_origin)
             constraint_set = self._resolve_origin(constraint_origin)
             if current_set - constraint_set:
-                print(
-                    "REJECT CONSTRAINT",
-                    parent_varname,
-                    current_set,
-                    constraint_set,
-                    node,
-                    state,
-                )
                 return
 
         varname = constraint.varname.get_varname()

--- a/pyanalyze/stacked_scopes.py
+++ b/pyanalyze/stacked_scopes.py
@@ -946,6 +946,14 @@ class FunctionScope(Scope):
             current_set = self._resolve_origin(current_origin)
             constraint_set = self._resolve_origin(constraint_origin)
             if current_set - constraint_set:
+                print(
+                    "REJECT CONSTRAINT",
+                    parent_varname,
+                    current_set,
+                    constraint_set,
+                    node,
+                    state,
+                )
                 return
 
         varname = constraint.varname.get_varname()

--- a/pyanalyze/test_name_check_visitor.py
+++ b/pyanalyze/test_name_check_visitor.py
@@ -763,22 +763,35 @@ class TestBoolOp(TestNameCheckVisitorBase):
             assert_is_value(
                 cond and 1,
                 MultiValuedValue([TypedValue(str), KnownValue(None), KnownValue(1)]),
+                skip_annotated=True,
             )
             assert_is_value(
-                cond2 and 1, MultiValuedValue([KnownValue(None), KnownValue(1)])
+                cond2 and 1,
+                MultiValuedValue([KnownValue(None), KnownValue(1)]),
+                skip_annotated=True,
             )
             assert_is_value(
-                cond or 1, MultiValuedValue([TypedValue(str), KnownValue(1)])
+                cond or 1,
+                MultiValuedValue([TypedValue(str), KnownValue(1)]),
+                skip_annotated=True,
             )
             assert_is_value(
-                cond2 or 1, MultiValuedValue([KnownValue(True), KnownValue(1)])
+                cond2 or 1,
+                MultiValuedValue([KnownValue(True), KnownValue(1)]),
+                skip_annotated=True,
             )
 
         def hutia(x=None):
             assert_is_value(x, AnyValue(AnySource.unannotated) | KnownValue(None))
-            assert_is_value(x or 1, AnyValue(AnySource.unannotated) | KnownValue(1))
+            assert_is_value(
+                x or 1,
+                AnyValue(AnySource.unannotated) | KnownValue(1),
+                skip_annotated=True,
+            )
             y = x or 1
-            assert_is_value(y, AnyValue(AnySource.unannotated) | KnownValue(1))
+            assert_is_value(
+                y, AnyValue(AnySource.unannotated) | KnownValue(1), skip_annotated=True
+            )
             assert_is_value(
                 (True if x else False) or None, KnownValue(True) | KnownValue(None)
             )
@@ -1727,7 +1740,7 @@ class TestOperators(TestNameCheckVisitorBase):
     @assert_passes(settings={ErrorCode.value_always_true: False})
     def test_not(self):
         def capybara(x):
-            assert_is_value(not x, TypedValue(bool))
+            assert_is_value(not x, TypedValue(bool), skip_annotated=True)
             assert_is_value(not True, KnownValue(False))
 
     @assert_passes()

--- a/pyanalyze/test_name_check_visitor.py
+++ b/pyanalyze/test_name_check_visitor.py
@@ -15,7 +15,7 @@ from .name_check_visitor import (
 )
 from .implementation import assert_is_value, dump_value
 from .error_code import DISABLED_IN_TESTS, ErrorCode
-from .stacked_scopes import Composite
+from .stacked_scopes import Composite, Varname
 from .test_config import TestConfig
 from .value import (
     AnnotatedValue,
@@ -140,7 +140,6 @@ def _make_module(code_str: str) -> types.ModuleType:
         make_weak=make_weak,
         UNINITIALIZED_VALUE=UNINITIALIZED_VALUE,
         NO_RETURN_VALUE=NO_RETURN_VALUE,
-        Composite=Composite,
     )
     return make_module(code_str, extra_scope)
 
@@ -1609,6 +1608,7 @@ class TestUnboundMethodValue(TestNameCheckVisitorBase):
     @assert_passes()
     def test_inference(self):
         from pyanalyze.tests import PropertyObject, ClassWithAsync
+        from pyanalyze.stacked_scopes import Composite
 
         def capybara(oid):
             assert_is_value(
@@ -1643,6 +1643,12 @@ class TestUnboundMethodValue(TestNameCheckVisitorBase):
 
     @assert_passes()
     def test_metaclass_super(self):
+        from pyanalyze.stacked_scopes import Composite, VarnameWithOrigin
+        from qcore.testing import Anything
+        from typing import Any, cast
+
+        varname = VarnameWithOrigin("self", cast(Any, Anything))
+
         class Metaclass(type):
             def __init__(self, name, bases, attrs):
                 super(Metaclass, self).__init__(name, bases, attrs)
@@ -1653,7 +1659,7 @@ class TestUnboundMethodValue(TestNameCheckVisitorBase):
                 assert_is_value(
                     self.__init__,
                     UnboundMethodValue(
-                        "__init__", Composite(TypedValue(Metaclass), "self")
+                        "__init__", Composite(TypedValue(Metaclass), varname)
                     ),
                 )
 

--- a/pyanalyze/test_stacked_scopes.py
+++ b/pyanalyze/test_stacked_scopes.py
@@ -949,6 +949,19 @@ class TestConstraints(TestNameCheckVisitorBase):
                     assert_is_value(b.attr.attr, TypedValue(int))
 
     @assert_passes()
+    def test_nested_scope(self):
+        class A:
+            pass
+
+        class B(A):
+            pass
+
+        def capybara(a: A, iterable):
+            if isinstance(a, B):
+                lst = [a for _ in iterable]
+                assert_is_value(lst, GenericValue(list, [TypedValue(B)]))
+
+    @assert_passes()
     def test_qcore_asserts(self):
         from qcore.asserts import assert_is_instance
 

--- a/pyanalyze/test_stacked_scopes.py
+++ b/pyanalyze/test_stacked_scopes.py
@@ -1609,7 +1609,7 @@ class TestComposite(TestNameCheckVisitorBase):
     def test_subscript(self):
         from typing import Any, Dict
 
-        def capybara(x: Dict[str, Any]) -> None:
+        def capybara(x: Dict[str, Any], y) -> None:
             assert_is_value(x["a"], AnyValue(AnySource.explicit))
             x["a"] = 1
             assert_is_value(x["a"], KnownValue(1))

--- a/pyanalyze/test_stacked_scopes.py
+++ b/pyanalyze/test_stacked_scopes.py
@@ -1703,3 +1703,16 @@ class TestInvalidation(TestNameCheckVisitorBase):
             if callee(y):
                 assert_is_value(x, AnyValue(AnySource.unannotated))
                 assert_is_value(y, AnyValue(AnySource.unannotated))
+
+    @assert_passes()
+    def test_while(self) -> None:
+        from typing import Optional
+
+        def make_optional() -> Optional[str]:
+            return "x"
+
+        def capybara():
+            x = make_optional()
+            while x:
+                assert_is_value(x, TypedValue(str))
+                x = make_optional()

--- a/pyanalyze/test_stacked_scopes.py
+++ b/pyanalyze/test_stacked_scopes.py
@@ -930,8 +930,27 @@ class TestConstraints(TestNameCheckVisitorBase):
                 assert_is_value(x, KnownValue(False))
 
     @assert_passes()
+    def test_double_index(self):
+        from typing import Union, Optional
+
+        class A:
+            attr: Union[int, str]
+
+        class B:
+            attr: Optional[A]
+
+        def capybara(b: B):
+            assert_is_value(b, TypedValue(B))
+            assert_is_value(b.attr, TypedValue(A) | KnownValue(None))
+            if b.attr is not None:
+                assert_is_value(b.attr, TypedValue(A))
+                assert_is_value(b.attr.attr, TypedValue(int) | TypedValue(str))
+                if isinstance(b.attr.attr, int):
+                    assert_is_value(b.attr.attr, TypedValue(int))
+
+    @assert_passes()
     def test_qcore_asserts(self):
-        from qcore.asserts import assert_is, assert_is_not, assert_is_instance
+        from qcore.asserts import assert_is_instance
 
         def capybara(cond):
             if cond:

--- a/pyanalyze/test_stacked_scopes.py
+++ b/pyanalyze/test_stacked_scopes.py
@@ -854,40 +854,40 @@ class TestConstraints(TestNameCheckVisitorBase):
 
     @assert_passes()
     def test_isinstance(self):
-        class A(object):
-            pass
+        # class A(object):
+        #     pass
 
-        class B(A):
-            pass
+        # class B(A):
+        #     pass
 
-        class C(A):
-            pass
+        # class C(A):
+        #     pass
 
-        def capybara(x):
-            assert_is_value(x, AnyValue(AnySource.unannotated))
-            if isinstance(x, int):
-                assert_is_value(x, TypedValue(int))
-            else:
-                assert_is_value(x, AnyValue(AnySource.unannotated))
+        # def capybara(x):
+        #     assert_is_value(x, AnyValue(AnySource.unannotated))
+        #     if isinstance(x, int):
+        #         assert_is_value(x, TypedValue(int))
+        #     else:
+        #         assert_is_value(x, AnyValue(AnySource.unannotated))
 
-            if isinstance(x, A):
-                assert_is_value(x, TypedValue(A))
-                if isinstance(x, B):
-                    assert_is_value(x, TypedValue(B))
-                    if isinstance(x, C):
-                        # Incompatible constraints result in Any.
-                        assert_is_value(x, AnyValue(AnySource.unreachable))
-            if isinstance(x, B):
-                assert_is_value(x, TypedValue(B))
-                if isinstance(x, A):
-                    # Less precise constraints are ignored.
-                    assert_is_value(x, TypedValue(B))
+        #     if isinstance(x, A):
+        #         assert_is_value(x, TypedValue(A))
+        #         if isinstance(x, B):
+        #             assert_is_value(x, TypedValue(B))
+        #             if isinstance(x, C):
+        #                 # Incompatible constraints result in Any.
+        #                 assert_is_value(x, AnyValue(AnySource.unreachable))
+        #     if isinstance(x, B):
+        #         assert_is_value(x, TypedValue(B))
+        #         if isinstance(x, A):
+        #             # Less precise constraints are ignored.
+        #             assert_is_value(x, TypedValue(B))
 
-            x = B()
-            assert_is_value(x, TypedValue(B))
-            if isinstance(x, A):
-                # Don't widen the type to A.
-                assert_is_value(x, TypedValue(B))
+        #     x = B()
+        #     assert_is_value(x, TypedValue(B))
+        #     if isinstance(x, A):
+        #         # Don't widen the type to A.
+        #         assert_is_value(x, TypedValue(B))
 
         def kerodon(cond1, cond2, val, lst: list):
             if cond1:
@@ -901,34 +901,34 @@ class TestConstraints(TestNameCheckVisitorBase):
                 MultiValuedValue([TypedValue(int), TypedValue(str), TypedValue(list)]),
             )
 
-            if isinstance(x, (int, str)):
-                assert_is_value(x, MultiValuedValue([TypedValue(int), TypedValue(str)]))
-            else:
-                assert_is_value(x, TypedValue(list))
+            # if isinstance(x, (int, str)):
+            #     assert_is_value(x, MultiValuedValue([TypedValue(int), TypedValue(str)]))
+            # else:
+            #     assert_is_value(x, TypedValue(list))
 
-            assert_is_value(
-                x,
-                MultiValuedValue([TypedValue(int), TypedValue(str), TypedValue(list)]),
-            )
+            # assert_is_value(
+            #     x,
+            #     MultiValuedValue([TypedValue(int), TypedValue(str), TypedValue(list)]),
+            # )
             if isinstance(x, int) or isinstance(x, str):
                 assert_is_value(x, MultiValuedValue([TypedValue(int), TypedValue(str)]))
-            else:
-                assert_is_value(x, TypedValue(list))
+            # else:
+            #     assert_is_value(x, TypedValue(list))
 
-        def paca(cond1, cond2):
-            if cond1:
-                x = True
-            elif cond2:
-                x = False
-            else:
-                x = None
+        # def paca(cond1, cond2):
+        #     if cond1:
+        #         x = True
+        #     elif cond2:
+        #         x = False
+        #     else:
+        #         x = None
 
-            if (x is not True and x is not False) or (x is True):
-                assert_is_value(
-                    x, MultiValuedValue([KnownValue(None), KnownValue(True)])
-                )
-            else:
-                assert_is_value(x, KnownValue(False))
+        #     if (x is not True and x is not False) or (x is True):
+        #         assert_is_value(
+        #             x, MultiValuedValue([KnownValue(None), KnownValue(True)])
+        #         )
+        #     else:
+        #         assert_is_value(x, KnownValue(False))
 
     @assert_passes()
     def test_qcore_asserts(self):

--- a/pyanalyze/test_stacked_scopes.py
+++ b/pyanalyze/test_stacked_scopes.py
@@ -1716,3 +1716,31 @@ class TestInvalidation(TestNameCheckVisitorBase):
             while x:
                 assert_is_value(x, TypedValue(str))
                 x = make_optional()
+
+    @assert_passes()
+    def test_len_condition(self) -> None:
+        def capybara(file_list, key, ids):
+            has_bias = len(key) > 0
+            data = []
+            for _ in file_list:
+                assert_is_value(key, AnyValue(AnySource.unannotated))
+                if has_bias:
+                    assert_is_value(key, AnyValue(AnySource.unannotated))
+                    data = [ids, data[key]]
+                else:
+                    data = [ids]
+
+    @assert_passes()
+    def test_len_condition_with_type(self) -> None:
+        from typing import Optional
+
+        def capybara(file_list, key: Optional[int], ids):
+            has_bias = key is not None
+            data = []
+            for _ in file_list:
+                assert_is_value(key, TypedValue(int) | KnownValue(None))
+                if has_bias:
+                    assert_is_value(key, TypedValue(int))
+                    data = [ids, data[key]]
+                else:
+                    data = [ids]

--- a/pyanalyze/test_stacked_scopes.py
+++ b/pyanalyze/test_stacked_scopes.py
@@ -853,40 +853,40 @@ class TestConstraints(TestNameCheckVisitorBase):
 
     @assert_passes()
     def test_isinstance(self):
-        # class A(object):
-        #     pass
+        class A(object):
+            pass
 
-        # class B(A):
-        #     pass
+        class B(A):
+            pass
 
-        # class C(A):
-        #     pass
+        class C(A):
+            pass
 
-        # def capybara(x):
-        #     assert_is_value(x, AnyValue(AnySource.unannotated))
-        #     if isinstance(x, int):
-        #         assert_is_value(x, TypedValue(int))
-        #     else:
-        #         assert_is_value(x, AnyValue(AnySource.unannotated))
+        def capybara(x):
+            assert_is_value(x, AnyValue(AnySource.unannotated))
+            if isinstance(x, int):
+                assert_is_value(x, TypedValue(int))
+            else:
+                assert_is_value(x, AnyValue(AnySource.unannotated))
 
-        #     if isinstance(x, A):
-        #         assert_is_value(x, TypedValue(A))
-        #         if isinstance(x, B):
-        #             assert_is_value(x, TypedValue(B))
-        #             if isinstance(x, C):
-        #                 # Incompatible constraints result in Any.
-        #                 assert_is_value(x, AnyValue(AnySource.unreachable))
-        #     if isinstance(x, B):
-        #         assert_is_value(x, TypedValue(B))
-        #         if isinstance(x, A):
-        #             # Less precise constraints are ignored.
-        #             assert_is_value(x, TypedValue(B))
+            if isinstance(x, A):
+                assert_is_value(x, TypedValue(A))
+                if isinstance(x, B):
+                    assert_is_value(x, TypedValue(B))
+                    if isinstance(x, C):
+                        # Incompatible constraints result in Any.
+                        assert_is_value(x, AnyValue(AnySource.unreachable))
+            if isinstance(x, B):
+                assert_is_value(x, TypedValue(B))
+                if isinstance(x, A):
+                    # Less precise constraints are ignored.
+                    assert_is_value(x, TypedValue(B))
 
-        #     x = B()
-        #     assert_is_value(x, TypedValue(B))
-        #     if isinstance(x, A):
-        #         # Don't widen the type to A.
-        #         assert_is_value(x, TypedValue(B))
+            x = B()
+            assert_is_value(x, TypedValue(B))
+            if isinstance(x, A):
+                # Don't widen the type to A.
+                assert_is_value(x, TypedValue(B))
 
         def kerodon(cond1, cond2, val, lst: list):
             if cond1:
@@ -900,34 +900,34 @@ class TestConstraints(TestNameCheckVisitorBase):
                 MultiValuedValue([TypedValue(int), TypedValue(str), TypedValue(list)]),
             )
 
-            # if isinstance(x, (int, str)):
-            #     assert_is_value(x, MultiValuedValue([TypedValue(int), TypedValue(str)]))
-            # else:
-            #     assert_is_value(x, TypedValue(list))
+            if isinstance(x, (int, str)):
+                assert_is_value(x, MultiValuedValue([TypedValue(int), TypedValue(str)]))
+            else:
+                assert_is_value(x, TypedValue(list))
 
-            # assert_is_value(
-            #     x,
-            #     MultiValuedValue([TypedValue(int), TypedValue(str), TypedValue(list)]),
-            # )
+            assert_is_value(
+                x,
+                MultiValuedValue([TypedValue(int), TypedValue(str), TypedValue(list)]),
+            )
             if isinstance(x, int) or isinstance(x, str):
                 assert_is_value(x, MultiValuedValue([TypedValue(int), TypedValue(str)]))
-            # else:
-            #     assert_is_value(x, TypedValue(list))
+            else:
+                assert_is_value(x, TypedValue(list))
 
-        # def paca(cond1, cond2):
-        #     if cond1:
-        #         x = True
-        #     elif cond2:
-        #         x = False
-        #     else:
-        #         x = None
+        def paca(cond1, cond2):
+            if cond1:
+                x = True
+            elif cond2:
+                x = False
+            else:
+                x = None
 
-        #     if (x is not True and x is not False) or (x is True):
-        #         assert_is_value(
-        #             x, MultiValuedValue([KnownValue(None), KnownValue(True)])
-        #         )
-        #     else:
-        #         assert_is_value(x, KnownValue(False))
+            if (x is not True and x is not False) or (x is True):
+                assert_is_value(
+                    x, MultiValuedValue([KnownValue(None), KnownValue(True)])
+                )
+            else:
+                assert_is_value(x, KnownValue(False))
 
     @assert_passes()
     def test_qcore_asserts(self):

--- a/pyanalyze/test_stacked_scopes.py
+++ b/pyanalyze/test_stacked_scopes.py
@@ -950,6 +950,8 @@ class TestConstraints(TestNameCheckVisitorBase):
 
     @assert_passes()
     def test_nested_scope(self):
+        from pyanalyze.value import WeakExtension
+
         class A:
             pass
 
@@ -958,8 +960,14 @@ class TestConstraints(TestNameCheckVisitorBase):
 
         def capybara(a: A, iterable):
             if isinstance(a, B):
+                assert_is_value(a, TypedValue(B))
                 lst = [a for _ in iterable]
-                assert_is_value(lst, GenericValue(list, [TypedValue(B)]))
+                assert_is_value(
+                    lst,
+                    AnnotatedValue(
+                        GenericValue(list, [TypedValue(B)]), [WeakExtension()]
+                    ),
+                )
 
     @assert_passes()
     def test_qcore_asserts(self):

--- a/pyanalyze/test_stacked_scopes.py
+++ b/pyanalyze/test_stacked_scopes.py
@@ -1,5 +1,4 @@
 # static analysis: ignore
-from pyanalyze.extensions import reveal_type
 from .error_code import ErrorCode
 from .name_check_visitor import build_stacked_scopes
 from .stacked_scopes import ScopeType, uniq_chain

--- a/pyanalyze/test_stacked_scopes.py
+++ b/pyanalyze/test_stacked_scopes.py
@@ -1,4 +1,5 @@
 # static analysis: ignore
+from pyanalyze.extensions import reveal_type
 from .error_code import ErrorCode
 from .name_check_visitor import build_stacked_scopes
 from .stacked_scopes import ScopeType, uniq_chain

--- a/pyanalyze/test_value.py
+++ b/pyanalyze/test_value.py
@@ -33,6 +33,7 @@ from .value import (
     SequenceIncompleteValue,
     TypeVarMap,
     concrete_values_from_iterable,
+    unite_and_simplify,
 )
 
 _checker = Checker(TestConfig())
@@ -562,3 +563,10 @@ def test_pickling() -> None:
     _assert_pickling_roundtrip(KnownValue(1))
     _assert_pickling_roundtrip(TypedValue(int))
     _assert_pickling_roundtrip(KnownValue(None) | TypedValue(str))
+
+
+def test_unite_and_simplify() -> None:
+    vals = [GenericValue(list, [TypedValue(int)]), KnownValue([])]
+    assert unite_and_simplify(*vals, limit=2) == GenericValue(
+        list, [TypedValue(int)]
+    ) | GenericValue(list, [AnyValue(AnySource.unreachable)])

--- a/pyanalyze/value.py
+++ b/pyanalyze/value.py
@@ -56,6 +56,7 @@ T = TypeVar("T")
 # __builtin__ in Python 2 and builtins in Python 3
 BUILTIN_MODULE = str.__module__
 KNOWN_MUTABLE_TYPES = (list, set, dict, deque)
+ITERATION_LIMIT = 1000
 
 TypeVarMap = Mapping["TypeVar", "Value"]
 GenericBases = Mapping[Union[type, str], TypeVarMap]
@@ -1987,7 +1988,10 @@ def concrete_values_from_iterable(
         if all(pair.is_required and not pair.is_many for pair in value.kv_pairs):
             return [pair.key for pair in value.kv_pairs]
     elif isinstance(value, KnownValue):
-        if isinstance(value.val, (str, bytes, range)):
+        if (
+            isinstance(value.val, (str, bytes, range))
+            and len(value.val) < ITERATION_LIMIT
+        ):
             return [KnownValue(c) for c in value.val]
     elif value is NO_RETURN_VALUE:
         return NO_RETURN_VALUE

--- a/pyanalyze/value.py
+++ b/pyanalyze/value.py
@@ -1866,12 +1866,14 @@ def annotate_value(origin: Value, metadata: Sequence[Union[Value, Extension]]) -
     return AnnotatedValue(origin, metadata)
 
 
-def unite_and_simplify(*values: Value, limit: int) -> Value:
-    united = unite_values(*values)
+def unite_and_simplify(
+    *values: Value, limit: int, default: Value = NO_RETURN_VALUE
+) -> Value:
+    united = unite_values(*values, default=default)
     if not isinstance(united, MultiValuedValue) or len(united.vals) < limit:
         return united
     simplified = [val.simplify() for val in united.vals]
-    return unite_values(*simplified)
+    return unite_values(*simplified, default=default)
 
 
 def unite_values(*values: Value, default: Value = NO_RETURN_VALUE) -> Value:

--- a/pyanalyze/value.py
+++ b/pyanalyze/value.py
@@ -1654,12 +1654,16 @@ class HasAttrExtension(Extension):
         yield from self.attribute_type.walk_values()
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, eq=False)
 class ConstraintExtension(Extension):
     """Encapsulates a Constraint. If the value is evaluated and is truthy, the
     constraint must be True."""
 
     constraint: "pyanalyze.stacked_scopes.AbstractConstraint"
+
+    # Comparing them can get too expensive
+    def __hash__(self) -> int:
+        return id(self)
 
 
 @dataclass(frozen=True)

--- a/pyanalyze/value.py
+++ b/pyanalyze/value.py
@@ -822,7 +822,7 @@ class GenericValue(TypedValue):
             self.typ, [arg.substitute_typevars(typevars) for arg in self.args]
         )
 
-    def simplify(self, default) -> Value:
+    def simplify(self, default: Value) -> Value:
         return GenericValue(self.typ, [arg.simplify(default) for arg in self.args])
 
 

--- a/pyanalyze/value.py
+++ b/pyanalyze/value.py
@@ -1874,7 +1874,7 @@ def unite_and_simplify(*values: Value, limit: int) -> Value:
     return unite_values(*simplified)
 
 
-def unite_values(*values: Value) -> Value:
+def unite_values(*values: Value, default: Value = NO_RETURN_VALUE) -> Value:
     """Unite multiple values into a single :class:`Value`.
 
     This collapses equal values and returns a :class:`MultiValuedValue`
@@ -1882,7 +1882,7 @@ def unite_values(*values: Value) -> Value:
 
     """
     if not values:
-        return NO_RETURN_VALUE
+        return default
     # Make sure order is consistent; conceptually this is a set but
     # sets have unpredictable iteration order.
     hashable_vals = OrderedDict()
@@ -1908,7 +1908,7 @@ def unite_values(*values: Value) -> Value:
     existing = list(hashable_vals) + unhashable_vals
     num = len(existing)
     if num == 0:
-        return NO_RETURN_VALUE
+        return default
     if num == 1:
         return existing[0]
     else:

--- a/pyanalyze/value.py
+++ b/pyanalyze/value.py
@@ -1879,7 +1879,7 @@ def annotate_value(origin: Value, metadata: Sequence[Union[Value, Extension]]) -
 
 
 def unite_and_simplify(
-    *values: Value, limit: int, default: Value = NO_RETURN_VALUE
+    *values: Value, limit: int, default: Value = AnyValue(AnySource.unreachable)
 ) -> Value:
     united = unite_values(*values, default=default)
     if not isinstance(united, MultiValuedValue) or len(united.vals) < limit:


### PR DESCRIPTION
This allows storing constraints in variables. As a result, we need a way to invalidate constraints if the underlying variable has been reassigned since the constraint was created, and to that end each Varname is now associated with an origin, the nodes in which it was defined.