### PR TITLE
Fix bug that led to some overloaded calls incorrectly resolving to `Any`

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix bug that led to some overloaded calls incorrectly
+  resolving to `Any` (#462)
 - Support `__init__` and `__new__` signatures from typeshed (#429)
 - Fix incorrect type inferred for indexing operations on
   subclasses of `list` and `tuple` (#461)

--- a/pyanalyze/name_check_visitor.py
+++ b/pyanalyze/name_check_visitor.py
@@ -2173,7 +2173,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
             f.flush()
             f.seek(0)
             try:
-                pseudo_module = importer.import_module(pseudo_module_name, f.name)
+                pseudo_module = importer.import_module(pseudo_module_name, Path(f.name))
             except Exception:
                 # sets the name of the imported module to Any so we don't get further
                 # errors

--- a/pyanalyze/signature.py
+++ b/pyanalyze/signature.py
@@ -598,6 +598,8 @@ class Signature:
             bounds_map, used_any = can_assign_and_used_any(
                 param_typ, composite.value, ctx.can_assign_ctx
             )
+            if composite.value is param.default:
+                used_any = False
             if isinstance(bounds_map, CanAssignError):
                 if composite.value is param.default:
                     bounds_map = {}

--- a/pyanalyze/stubs/_pyanalyze_tests-stubs/overloaded.pyi
+++ b/pyanalyze/stubs/_pyanalyze_tests-stubs/overloaded.pyi
@@ -1,0 +1,9 @@
+from typing import overload
+from typing_extensions import Literal
+
+@overload
+def func(x: int, y: Literal[1] = ..., z: str = ...) -> int: ...
+@overload
+def func(x: int, y: int, z: str = ...) -> str: ...
+@overload
+def func(x: str, y: int = ..., z: str = ...) -> float: ...

--- a/pyanalyze/test_signature.py
+++ b/pyanalyze/test_signature.py
@@ -1110,3 +1110,14 @@ class TestOverload(TestNameCheckVisitorBase):
             f(1.0)  # E: incompatible_argument
             f(1, 1)  # E: incompatible_argument
             f(1, 1, 1)  # E: incompatible_call
+
+    @assert_passes()
+    def test_ellipsis_default(self):
+        from pyanalyze.extensions import assert_type
+
+        def wrapper():
+            from _pyanalyze_tests.overloaded import func
+
+            assert_type(func(1), int)
+            assert_type(func(1, 1), int)
+            assert_type(func("x"), float)

--- a/pyanalyze/test_typeshed.py
+++ b/pyanalyze/test_typeshed.py
@@ -21,10 +21,11 @@ from .extensions import evaluated
 from .test_config import TEST_OPTIONS
 from .test_name_check_visitor import TestNameCheckVisitorBase
 from .test_node_visitor import assert_passes
-from .signature import SigParameter, Signature
+from .signature import OverloadedSignature, SigParameter, Signature
 from .test_arg_spec import ClassWithCall
 from .typeshed import TypeshedFinder
 from .value import (
+    CallableValue,
     SubclassValue,
     TypedDictValue,
     assert_is_value,
@@ -195,6 +196,13 @@ class TestBundledStubs(TestNameCheckVisitorBase):
         assert tsf.resolve_name(mod, "constant") == TypedValue(int)
         assert tsf.resolve_name(mod, "aliased_constant") == TypedValue(int)
         assert tsf.resolve_name(mod, "explicitly_aliased_constant") == TypedValue(int)
+
+    def test_overloaded(self):
+        tsf = TypeshedFinder.make(Checker(), TEST_OPTIONS, verbose=True)
+        mod = "_pyanalyze_tests.overloaded"
+        val = tsf.resolve_name(mod, "func")
+        assert isinstance(val, CallableValue)
+        assert isinstance(val.signature, OverloadedSignature)
 
     def test_typeddict(self):
         tsf = TypeshedFinder.make(Checker(), TEST_OPTIONS, verbose=True)
@@ -608,19 +616,3 @@ class TestParamSpec(TestNameCheckVisitorBase):
                 GenericValue(contextlib._GeneratorContextManager, [TypedValue(str)]),
             )
             wrapped("x")  # E: incompatible_argument
-
-
-class TestOpen(TestNameCheckVisitorBase):
-    @assert_passes()
-    def test_basic(self):
-        import io
-        from typing import BinaryIO, IO, Any
-        from pyanalyze.extensions import assert_type
-
-        def capybara(buffering: int, mode: str):
-            assert_type(open("x"), io.TextIOWrapper)
-            assert_type(open("x", "r"), io.TextIOWrapper)
-            assert_type(open("x", "rb"), io.BufferedReader)
-            assert_type(open("x", "rb", buffering=0), io.FileIO)
-            assert_type(open("x", "rb", buffering=buffering), BinaryIO)
-            assert_type(open("x", mode, buffering=buffering), IO[Any])

--- a/pyanalyze/test_typeshed.py
+++ b/pyanalyze/test_typeshed.py
@@ -608,3 +608,19 @@ class TestParamSpec(TestNameCheckVisitorBase):
                 GenericValue(contextlib._GeneratorContextManager, [TypedValue(str)]),
             )
             wrapped("x")  # E: incompatible_argument
+
+
+class TestOpen(TestNameCheckVisitorBase):
+    @assert_passes()
+    def test_basic(self):
+        import io
+        from typing import BinaryIO, IO, Any
+        from pyanalyze.extensions import assert_type
+
+        def capybara(buffering: int, mode: str):
+            assert_type(open("x"), io.TextIOWrapper)
+            assert_type(open("x", "r"), io.TextIOWrapper)
+            assert_type(open("x", "rb"), io.BufferedReader)
+            assert_type(open("x", "rb", buffering=0), io.FileIO)
+            assert_type(open("x", "rb", buffering=buffering), BinaryIO)
+            assert_type(open("x", mode, buffering=buffering), IO[Any])

--- a/pyanalyze/typeshed.py
+++ b/pyanalyze/typeshed.py
@@ -651,6 +651,9 @@ class TypeshedFinder:
     def _get_fq_name(self, obj: Any) -> Optional[str]:
         if obj is GeneratorType:
             return "typing.Generator"
+        # It claims to be io.open, but typeshed puts it in builtins
+        if obj is open:
+            return "builtins.open"
         if IS_PRE_38:
             if obj is Sized:
                 return "typing.Sized"

--- a/pyanalyze/typeshed.py
+++ b/pyanalyze/typeshed.py
@@ -651,9 +651,6 @@ class TypeshedFinder:
     def _get_fq_name(self, obj: Any) -> Optional[str]:
         if obj is GeneratorType:
             return "typing.Generator"
-        # It claims to be io.open, but typeshed puts it in builtins
-        if obj is open:
-            return "builtins.open"
         if IS_PRE_38:
             if obj is Sized:
                 return "typing.Sized"
@@ -1067,7 +1064,14 @@ class TypeshedFinder:
                         return val
                     if info.ast.value:
                         return self._parse_expr(info.ast.value, module)
-                elif isinstance(info.ast, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                elif isinstance(
+                    info.ast,
+                    (
+                        ast.FunctionDef,
+                        ast.AsyncFunctionDef,
+                        typeshed_client.OverloadedName,
+                    ),
+                ):
                     sig = self._get_signature_from_info(info, None, fq_name, module)
                     if sig is not None:
                         return CallableValue(sig)


### PR DESCRIPTION
Specifically, in cases where the default was Any and the default was used. This is most likely to happen with stubs, where the default value is always `...`.