### PR TITLE
Remove support for detecting properties that represent synchronous equivalents of asynq methods

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Remove support for detecting properties that represent
+  synchronous equivalents of asynq methods (#493)
 - Enable exhaustive checking of enums and booleans (#492)
 - Fix type narrowing in else branch if constraint is stored in a
   variable (#491)

--- a/pyanalyze/name_check_visitor.py
+++ b/pyanalyze/name_check_visitor.py
@@ -4060,9 +4060,6 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
             return Composite(self.being_assigned, composite, node)
         elif self._is_read_ctx(node.ctx):
             if self._is_checking():
-                self.asynq_checker.record_attribute_access(
-                    root_composite.value, node.attr, node
-                )
                 if (
                     isinstance(root_composite.value, KnownValue)
                     and isinstance(root_composite.value.val, types.ModuleType)

--- a/pyanalyze/test_asynq_checker.py
+++ b/pyanalyze/test_asynq_checker.py
@@ -84,16 +84,6 @@ class TestImpureAsyncCalls(TestNameCheckVisitorBase):
                 return str(log)
 
     @assert_passes()
-    def test_impure_async_property_access(self):
-        from pyanalyze.tests import PropertyObject
-        from asynq import asynq
-
-        @asynq()
-        def get_capybara(qid):
-            po = PropertyObject(qid)
-            return po.prop_with_get  # E: impure_async_call
-
-    @assert_passes()
     def test_async_property_access(self):
         from pyanalyze.tests import PropertyObject
         from asynq import asynq, result
@@ -207,18 +197,6 @@ def capybara():
                 z = []
                 z += self.render_stuff()  # E: impure_async_call
                 return z
-
-    @assert_passes()
-    def test_impure_async_for_attributes(self):
-        from pyanalyze.tests import PropertyObject, CheckedForAsynq
-
-        class Capybara(CheckedForAsynq):
-            def init(self, qid):
-                self.qid = qid
-
-            def tree(self):
-                PropertyObject(self.qid).prop_with_get  # E: impure_async_call
-                return []
 
     @assert_passes()
     def test_pure_async_for_attributes(self):


### PR DESCRIPTION
We no longer need this internally.
﻿
