### PR TITLE
Remove sorted() signature

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Remove special-cased signatured for `sorted()` (#498)
 - Support type narrowing on `bool()` calls (#497)
 - Support context managers that may suppress exceptions (#496)
 - Fix type inference for `with` assignment targets on

--- a/pyanalyze/implementation.py
+++ b/pyanalyze/implementation.py
@@ -69,18 +69,7 @@ import warnings
 from types import FunctionType
 import typing
 import typing_extensions
-from typing import (
-    Sequence,
-    TypeVar,
-    cast,
-    Dict,
-    NewType,
-    Callable,
-    Optional,
-    Union,
-    Any,
-)
-from typing_extensions import Protocol
+from typing import Sequence, TypeVar, cast, Dict, NewType, Callable, Optional, Union
 
 _NO_ARG_SENTINEL = KnownValue(qcore.MarkerObject("no argument given"))
 
@@ -1267,11 +1256,6 @@ _ENCODING_PARAMETER = SigParameter(
 T = TypeVar("T")
 K = TypeVar("K")
 V = TypeVar("V")
-
-
-class SupportsLessThan(Protocol):
-    def __lt__(self, __other: Any) -> bool:
-        raise NotImplementedError
 
 
 def get_default_argspecs() -> Dict[object, Signature]:

--- a/pyanalyze/implementation.py
+++ b/pyanalyze/implementation.py
@@ -1686,42 +1686,6 @@ def get_default_argspecs() -> Dict[object, Signature]:
             callable=bool,
             impl=_bool_impl,
         ),
-        # The overloaded annotation in typeshed causes a couple of problems:
-        # - sorted(Sequence[A] | Sequence[B]) turns into List[A | B] instead of List[A] | List[B]
-        #   pyright agrees with pyanalyze here but mypy somehow infers the second type.
-        # - The bounded TypeVar on the key argument makes pyanalyze infer the
-        #   return type as list[Sized] if we use key=len. Fixing this may require changing the
-        #   TypeVar resolution algorithm.
-        # To avoid these problems, we use a more permissive hardcoded signature for now.
-        Signature.make(
-            [
-                SigParameter(
-                    "iterable",
-                    ParameterKind.POSITIONAL_ONLY,
-                    annotation=TypedValue(collections.abc.Iterable),
-                ),
-                SigParameter(
-                    "key",
-                    ParameterKind.KEYWORD_ONLY,
-                    annotation=CallableValue(
-                        Signature.make(
-                            [SigParameter("arg", ParameterKind.POSITIONAL_ONLY)],
-                            return_annotation=TypedValue(SupportsLessThan),
-                        )
-                    ),
-                    default=KnownValue(None),
-                ),
-                SigParameter(
-                    "reverse",
-                    ParameterKind.KEYWORD_ONLY,
-                    annotation=TypedValue(bool),
-                    default=KnownValue(False),
-                ),
-            ],
-            return_annotation=TypedValue(list),
-            allow_call=True,
-            callable=sorted,
-        ),
         # TypeGuards, which aren't in typeshed yet
         Signature.make(
             [


### PR DESCRIPTION
This was added because using typeshed exposed some TypeVar bugs
previously. But now pyanalyze's TypeVar resolution algorithm is
better and we shouldn't need this special case any more.
