### PR TITLE
Start support for Python 3.11

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Partial support for running on Python 3.11 (#512)
 - Basic support for checking `Final` and for checking re-assignments
   to variables declared with a specific type (#505)
 - Correctly check the `self` argument to `@property` getters (#506)

--- a/pyanalyze/annotations.py
+++ b/pyanalyze/annotations.py
@@ -384,7 +384,10 @@ def _type_from_runtime(val: Any, ctx: Context, is_typeddict: bool = False) -> Va
     elif typing_inspect.is_tuple_type(val):
         args = typing_inspect.get_args(val)
         if not args:
-            return TypedValue(tuple)
+            if val is tuple or val is Tuple:
+                return TypedValue(tuple)
+            else:
+                return SequenceIncompleteValue(tuple, [])
         elif len(args) == 2 and args[1] is Ellipsis:
             return GenericValue(tuple, [_type_from_runtime(args[0], ctx)])
         elif len(args) == 1 and args[0] == ():
@@ -437,6 +440,8 @@ def _type_from_runtime(val: Any, ctx: Context, is_typeddict: bool = False) -> Va
         return _value_of_origin_args(Callable, args, val, ctx)
     elif val is AsynqCallable:
         return CallableValue(Signature.make([ELLIPSIS_PARAM], is_asynq=True))
+    elif val is typing.Any:
+        return AnyValue(AnySource.explicit)
     elif isinstance(val, type):
         return _maybe_typed_value(val)
     elif val is None:
@@ -445,8 +450,6 @@ def _type_from_runtime(val: Any, ctx: Context, is_typeddict: bool = False) -> Va
         return NO_RETURN_VALUE
     elif is_typing_name(val, "Self"):
         return SelfTVV
-    elif val is typing.Any:
-        return AnyValue(AnySource.explicit)
     elif hasattr(val, "__supertype__"):
         if isinstance(val.__supertype__, type):
             # NewType

--- a/pyanalyze/boolability.py
+++ b/pyanalyze/boolability.py
@@ -63,7 +63,8 @@ _FALSE_BOOLABILITIES = {
     Boolability.value_always_false,
     Boolability.value_always_false_mutable,
 }
-_ASYNQ_BOOL = asynq.FutureBase.__bool__
+# doesn't exist if asynq is not compiled
+_ASYNQ_BOOL = getattr(asynq.FutureBase, "__bool__", object())
 
 
 def get_boolability(value: Value) -> Boolability:

--- a/pyanalyze/name_check_visitor.py
+++ b/pyanalyze/name_check_visitor.py
@@ -277,6 +277,10 @@ COMPARATOR_TO_OPERATOR = {
     ast.NotIn: (_not_in, _in),
 }
 
+SAFE_DECORATORS_FOR_ARGSPEC_TO_RETVAL = [KnownValue(asynq.asynq), KnownValue(property)]
+if sys.version_info < (3, 11):
+    SAFE_DECORATORS_FOR_ARGSPEC_TO_RETVAL.append(KnownValue(asyncio.coroutine))
+
 
 class CustomContextManager(Protocol[T, U]):
     def __enter__(self) -> T:
@@ -1736,12 +1740,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
             return
         if info.node.decorator_list and not (
             len(info.decorators) == 1
-            and info.decorators[0][0]
-            in (
-                KnownValue(asynq.asynq),
-                KnownValue(asyncio.coroutine),
-                KnownValue(property),
-            )
+            and info.decorators[0][0] in SAFE_DECORATORS_FOR_ARGSPEC_TO_RETVAL
         ):
             return  # With decorators we don't know what it will return
         return_value = result.return_value

--- a/pyanalyze/test_async_await.py
+++ b/pyanalyze/test_async_await.py
@@ -9,7 +9,7 @@ from .value import (
     SequenceIncompleteValue,
 )
 from .implementation import assert_is_value
-from .test_node_visitor import assert_passes
+from .test_node_visitor import assert_passes, only_before
 from .test_name_check_visitor import TestNameCheckVisitorBase
 
 
@@ -99,6 +99,7 @@ class TestAsyncAwait(TestNameCheckVisitorBase):
 
 
 class TestMissingAwait(TestNameCheckVisitorBase):
+    @only_before((3, 11))
     @assert_passes()
     def test_asyncio_coroutine_internal(self):
         import asyncio
@@ -111,6 +112,7 @@ class TestMissingAwait(TestNameCheckVisitorBase):
         def g():
             f()  # E: missing_await
 
+    @only_before((3, 11))
     @assert_passes()
     def test_yield_from(self):
         import asyncio
@@ -123,6 +125,7 @@ class TestMissingAwait(TestNameCheckVisitorBase):
         def g():
             yield from f()
 
+    @only_before((3, 11))
     @assert_passes()
     def test_asyncio_coroutine_external(self):
         import asyncio
@@ -131,6 +134,7 @@ class TestMissingAwait(TestNameCheckVisitorBase):
         def f():
             asyncio.sleep(3)  # E: missing_await
 
+    @only_before((3, 11))
     def test_add_yield_from(self):
         self.assert_is_changed(
             """
@@ -149,6 +153,7 @@ class TestMissingAwait(TestNameCheckVisitorBase):
             """,
         )
 
+    @only_before((3, 11))
     @assert_passes()
     def test_has_yield_from_external(self):
         import asyncio
@@ -205,6 +210,7 @@ class TestMissingAwait(TestNameCheckVisitorBase):
 
 
 class TestArgSpec(TestNameCheckVisitorBase):
+    @only_before((3, 11))
     @assert_passes()
     def test_asyncio_coroutine(self):
         import asyncio


### PR DESCRIPTION
Enough to make it importable and to make most tests pass.

At least two bugs remain:
- It crashes on any Enum due to some issue with the base type resolver
- It incorrectly wants some "self" parameters to be annotated
