### PR TITLE
Remove WeakExtension

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add implementation function for `dict.pop` (#517)
+- Remove `WeakExtension` (#517)
 - Initial support for variable-length heterogeneous sequences
   (required for PEP 646). More precise types are now inferred
   for heterogeneous sequences containing variable-length

--- a/pyanalyze/arg_spec.py
+++ b/pyanalyze/arg_spec.py
@@ -50,7 +50,6 @@ from .value import (
     Value,
     TypeVarValue,
     extract_typevars,
-    make_weak,
 )
 import pyanalyze
 
@@ -206,7 +205,7 @@ class FunctionsSafeToCall(PyObjectSequenceOption[object]):
     arguments."""
 
     name = "functions_safe_to_call"
-    default_value = [sorted, asynq.asynq, make_weak]
+    default_value = [sorted, asynq.asynq]
 
 
 _HookReturn = Union[None, ConcreteSignature, inspect.Signature, Callable[..., Any]]

--- a/pyanalyze/test_async_await.py
+++ b/pyanalyze/test_async_await.py
@@ -1,6 +1,13 @@
 # static analysis: ignore
 from .tests import make_simple_sequence
-from .value import GenericValue, KnownValue, TypedValue, make_weak, AnyValue, AnySource
+from .value import (
+    GenericValue,
+    KnownValue,
+    SequenceValue,
+    TypedValue,
+    AnyValue,
+    AnySource,
+)
 from .implementation import assert_is_value
 from .test_node_visitor import assert_passes, only_before
 from .test_name_check_visitor import TestNameCheckVisitorBase
@@ -62,7 +69,7 @@ class TestAsyncAwait(TestNameCheckVisitorBase):
 
         async def f():
             x = [y async for y in AIter()]
-            assert_is_value(x, make_weak(GenericValue(list, [TypedValue(int)])))
+            assert_is_value(x, SequenceValue(list, [(True, TypedValue(int))]))
 
     @assert_passes()
     def test_async_generator(self):
@@ -82,7 +89,7 @@ class TestAsyncAwait(TestNameCheckVisitorBase):
             # TODO should be list[int] but we lose the type argument somewhere
             assert_is_value(
                 ints,
-                make_weak(GenericValue(list, [AnyValue(AnySource.generic_argument)])),
+                SequenceValue(list, [(True, AnyValue(AnySource.generic_argument))]),
             )
 
     @assert_passes()

--- a/pyanalyze/test_asynq.py
+++ b/pyanalyze/test_asynq.py
@@ -93,11 +93,14 @@ class TestUnwrapYield(TestNameCheckVisitorBase):
             vals4 = yield {i: square.asynq(i) for i in ints}
             assert_is_value(
                 vals4,
-                GenericValue(
+                DictIncompleteValue(
                     dict,
                     [
-                        MultiValuedValue([KnownValue(0), KnownValue(1), KnownValue(2)]),
-                        TypedValue(int),
+                        KVPair(
+                            KnownValue(0) | KnownValue(1) | KnownValue(2),
+                            TypedValue(int),
+                            is_many=True,
+                        )
                     ],
                 ),
             )

--- a/pyanalyze/test_asynq.py
+++ b/pyanalyze/test_asynq.py
@@ -6,9 +6,7 @@ from .value import (
     AnyValue,
     AsyncTaskIncompleteValue,
     KnownValue,
-    MultiValuedValue,
     TypedValue,
-    GenericValue,
     DictIncompleteValue,
     KVPair,
 )

--- a/pyanalyze/test_implementation.py
+++ b/pyanalyze/test_implementation.py
@@ -17,7 +17,6 @@ from .value import (
     DictIncompleteValue,
     SubclassValue,
     MultiValuedValue,
-    make_weak,
 )
 
 
@@ -635,27 +634,21 @@ class TestGenericMutators(TestNameCheckVisitorBase):
                 lst = [2 for _ in cond]
             assert_is_value(
                 lst,
-                MultiValuedValue(
-                    [
-                        make_weak(GenericValue(list, [KnownValue(1)])),
-                        make_weak(GenericValue(list, [KnownValue(2)])),
-                    ]
-                ),
+                SequenceValue(list, [(True, KnownValue(1))])
+                | SequenceValue(list, [(True, KnownValue(2))]),
             )
             lst.extend([3, 4])
 
             # TODO: this is wrong; it drops all but the last Union member
             assert_is_value(
                 lst,
-                make_weak(
-                    GenericValue(
-                        list,
-                        [
-                            MultiValuedValue(
-                                [KnownValue(2), KnownValue(3), KnownValue(4)]
-                            )
-                        ],
-                    )
+                SequenceValue(
+                    list,
+                    [
+                        (True, KnownValue(2)),
+                        (False, KnownValue(3)),
+                        (False, KnownValue(4)),
+                    ],
                 ),
             )
 
@@ -745,28 +738,32 @@ class TestGenericMutators(TestNameCheckVisitorBase):
             weak_dict = {i: str(i) for i in ints}
             assert_is_value(
                 weak_dict,
-                make_weak(GenericValue(dict, [TypedValue(int), TypedValue(str)])),
+                DictIncompleteValue(
+                    dict, [KVPair(TypedValue(int), TypedValue(str), is_many=True)]
+                ),
             )
             assert_is_value(weak_dict.setdefault(3, str(TD)), TypedValue(str))
 
-            int_or_3 = MultiValuedValue([TypedValue(int), KnownValue(3)])
-            assert_is_value(
-                weak_dict, make_weak(GenericValue(dict, [int_or_3, TypedValue(str)]))
-            )
-            assert_is_value(
-                weak_dict.setdefault(3),
-                MultiValuedValue([TypedValue(str), KnownValue(None)]),
-            )
             assert_is_value(
                 weak_dict,
-                make_weak(
-                    GenericValue(
-                        dict,
-                        [
-                            int_or_3,
-                            MultiValuedValue([TypedValue(str), KnownValue(None)]),
-                        ],
-                    )
+                DictIncompleteValue(
+                    dict,
+                    [
+                        KVPair(TypedValue(int), TypedValue(str), is_many=True),
+                        KVPair(KnownValue(3), TypedValue(str), is_required=False),
+                    ],
+                ),
+            )
+            assert_is_value(weak_dict.setdefault(3), TypedValue(str) | KnownValue(None))
+            assert_is_value(
+                weak_dict,
+                DictIncompleteValue(
+                    dict,
+                    [
+                        KVPair(TypedValue(int), TypedValue(str), is_many=True),
+                        KVPair(KnownValue(3), TypedValue(str), is_required=False),
+                        KVPair(KnownValue(3), KnownValue(None), is_required=False),
+                    ],
                 ),
             )
 
@@ -815,7 +812,6 @@ class TestGenericMutators(TestNameCheckVisitorBase):
     @assert_passes()
     def test_copy_and_update(self):
         from typing import Dict
-        from pyanalyze.value import WeakExtension
 
         def capybara():
             d1: Dict[str, int] = {"x": 1}
@@ -823,7 +819,12 @@ class TestGenericMutators(TestNameCheckVisitorBase):
             assert_is_value(d1, d1_val)
             d1[1] = 3  # E: incompatible_argument
             d2 = d1.copy()
-            assert_is_value(d2, AnnotatedValue(d1_val, [WeakExtension()]))
+            assert_is_value(
+                d2,
+                DictIncompleteValue(
+                    dict, [KVPair(TypedValue(str), TypedValue(int), is_many=True)]
+                ),
+            )
             d2[1] = 3
             assert_is_value(
                 d2,
@@ -1172,15 +1173,12 @@ class TestDictSetItem(TestNameCheckVisitorBase):
 
     @assert_passes()
     def test_weak(self):
-        from pyanalyze.value import WeakExtension
-
         def capybara(arg):
             dct = {int(k): 1 for k in arg}
             assert_is_value(
                 dct,
-                AnnotatedValue(
-                    GenericValue(dict, [TypedValue(int), KnownValue(1)]),
-                    [WeakExtension()],
+                DictIncompleteValue(
+                    dict, [KVPair(TypedValue(int), KnownValue(1), is_many=True)]
                 ),
             )
             dct["x"] = "y"

--- a/pyanalyze/test_implementation.py
+++ b/pyanalyze/test_implementation.py
@@ -833,6 +833,17 @@ class TestGenericMutators(TestNameCheckVisitorBase):
             assert_is_value(strong_dict, expected)
 
     @assert_passes()
+    def test_dict_pop_union(self):
+        def capybara(cond):
+            d = {"a": 1, "b": 2}
+            if cond:
+                d["c"] = 3
+            else:
+                d["d"] = 4
+
+            assert_is_value(d.pop("a"), KnownValue(1))
+
+    @assert_passes()
     def test_dict_update(self):
         def capybara():
             d1 = {}

--- a/pyanalyze/test_signature.py
+++ b/pyanalyze/test_signature.py
@@ -9,9 +9,9 @@ from .value import (
     CanAssignError,
     GenericValue,
     KnownValue,
+    SequenceValue,
     TypedDictValue,
     TypedValue,
-    make_weak,
 )
 from .implementation import assert_is_value
 from .test_name_check_visitor import TestNameCheckVisitorBase
@@ -507,8 +507,7 @@ class TestCalls(TestNameCheckVisitorBase):
         def run(elts):
             lst = [x for x in elts]
             assert_is_value(
-                lst,
-                make_weak(GenericValue(list, [AnyValue(AnySource.generic_argument)])),
+                lst, SequenceValue(list, [(True, AnyValue(AnySource.generic_argument))])
             )
             lst()  # E: not_callable
 

--- a/pyanalyze/test_typeshed.py
+++ b/pyanalyze/test_typeshed.py
@@ -27,6 +27,7 @@ from .tests import make_simple_sequence
 from .typeshed import TypeshedFinder
 from .value import (
     CallableValue,
+    DictIncompleteValue,
     SubclassValue,
     TypedDictValue,
     assert_is_value,
@@ -36,7 +37,7 @@ from .value import (
     NewTypeValue,
     TypedValue,
     GenericValue,
-    make_weak,
+    KVPair,
     TypeVarValue,
     UNINITIALIZED_VALUE,
     Value,
@@ -130,7 +131,9 @@ class TestTypeshedClient(TestNameCheckVisitorBase):
         def capybara(x: Dict[int, str]):
             assert_is_value(
                 {k: v for k, v in x.items()},
-                make_weak(GenericValue(dict, [TypedValue(int), TypedValue(str)])),
+                DictIncompleteValue(
+                    dict, [KVPair(TypedValue(int), TypedValue(str), is_many=True)]
+                ),
             )
 
     @assert_passes()

--- a/pyanalyze/value.py
+++ b/pyanalyze/value.py
@@ -2002,22 +2002,6 @@ class NoReturnConstraintExtension(Extension):
 
 
 @dataclass(frozen=True)
-class WeakExtension(Extension):
-    """Used to indicate that a generic argument to a container may be widened.
-
-    This is used only in conjuction with the special casing for functions
-    like ``list.extend``. After code like ``lst = [1, 2]; lst.extend([i for in range(5)])``
-    we may end up inferring a type like ``List[Literal[0, 1, 2, 3, 4]]``, but that is
-    too narrow and leads to false positives if later code puts a different int in
-    the list. If the generic argument is instead annotated with ``WeakExtension``, we
-    widen the type to accommodate later appends.
-
-    The ``TestGenericMutators.test_weak_value`` test case is an example.
-
-    """
-
-
-@dataclass(frozen=True)
 class AlwaysPresentExtension(Extension):
     """Extension that indicates that an iterable value is nonempty.
 
@@ -2235,10 +2219,6 @@ def intersect_bounds_maps(bounds_maps: Sequence[BoundsMap]) -> BoundsMap:
         for tv, bound_lists in intermediate.items()
         if all(tv in bounds_map for bounds_map in bounds_maps)
     }
-
-
-def make_weak(val: Value) -> Value:
-    return annotate_value(val, [WeakExtension()])
 
 
 def annotate_value(origin: Value, metadata: Sequence[Union[Value, Extension]]) -> Value:


### PR DESCRIPTION
With the new support for variable-length elements in SequenceValue,
we can use a SequenceValue with a single variable-length element
instead of a "weak" list. The behavior should be roughly equivalent.
