### PR TITLE
remove str.encode and bytes.decode impls

### DIFF
--- a/pyanalyze/implementation.py
+++ b/pyanalyze/implementation.py
@@ -1318,9 +1318,6 @@ def _bool_impl(ctx: CallContext) -> Value:
 
 
 _POS_ONLY = ParameterKind.POSITIONAL_ONLY
-_ENCODING_PARAMETER = SigParameter(
-    "encoding", annotation=TypedValue(str), default=KnownValue("")
-)
 
 T = TypeVar("T")
 K = TypeVar("K")
@@ -1630,30 +1627,6 @@ def get_default_argspecs() -> Dict[object, Signature]:
         ),
         Signature.make(
             [
-                SigParameter("self", _POS_ONLY, annotation=TypedValue(bytes)),
-                _ENCODING_PARAMETER,
-                SigParameter(
-                    "errors", annotation=TypedValue(str), default=KnownValue("")
-                ),
-            ],
-            TypedValue(str),
-            callable=bytes.decode,
-            allow_call=True,
-        ),
-        Signature.make(
-            [
-                SigParameter("self", _POS_ONLY, annotation=TypedValue(str)),
-                _ENCODING_PARAMETER,
-                SigParameter(
-                    "errors", annotation=TypedValue(str), default=KnownValue("")
-                ),
-            ],
-            TypedValue(bytes),
-            callable=str.encode,
-            allow_call=True,
-        ),
-        Signature.make(
-            [
                 SigParameter("self", _POS_ONLY, annotation=TypedValue(str)),
                 SigParameter("args", ParameterKind.VAR_POSITIONAL),
                 SigParameter("kwargs", ParameterKind.VAR_KEYWORD),
@@ -1751,7 +1724,6 @@ def get_default_argspecs() -> Dict[object, Signature]:
         except AttributeError:
             pass
         else:
-            # Anticipating https://bugs.python.org/issue46414
             sig = Signature.make(
                 [SigParameter("value", _POS_ONLY, annotation=TypeVarValue(T))],
                 TypeVarValue(T),
@@ -1759,7 +1731,6 @@ def get_default_argspecs() -> Dict[object, Signature]:
                 callable=reveal_type_func,
             )
             signatures.append(sig)
-        # Anticipating that this will be added to the stdlib
         try:
             assert_type_func = getattr(mod, "assert_type")
         except AttributeError:


### PR DESCRIPTION
They only add allow_call, and calling these doesn't seem particularly
useful.
