### PR TITLE
Allow CanAssignError to specify an error code

### DIFF
--- a/pyanalyze/signature.py
+++ b/pyanalyze/signature.py
@@ -638,7 +638,8 @@ class Signature:
                     ctx.on_error(
                         f"Incompatible argument type for {param.name}: expected"
                         f" {param_typ} but got {composite.value}",
-                        code=ErrorCode.incompatible_argument,
+                        code=bounds_map.get_error_code()
+                        or ErrorCode.incompatible_argument,
                         node=composite.node if composite.node is not None else None,
                         detail=str(bounds_map),
                     )

--- a/pyanalyze/value.py
+++ b/pyanalyze/value.py
@@ -50,6 +50,7 @@ import qcore
 from typing_extensions import Literal, ParamSpec, Protocol
 
 import pyanalyze
+from pyanalyze.error_code import ErrorCode
 from pyanalyze.extensions import CustomCheck
 
 from .safe import all_of_type, safe_equals, safe_isinstance, safe_issubclass
@@ -269,6 +270,7 @@ class CanAssignError:
 
     message: str = ""
     children: List["CanAssignError"] = field(default_factory=list)
+    error_code: Optional[ErrorCode] = None
 
     def display(self, depth: int = 2) -> str:
         """Display all errors in a human-readable format."""
@@ -280,6 +282,14 @@ class CanAssignError:
             return f"{message}\n{child_result}"
         else:
             return child_result
+
+    def get_error_code(self) -> Optional[ErrorCode]:
+        errors = {child.get_error_code() for child in self.children}
+        if self.error_code:
+            errors.add(self.error_code)
+        if len(errors) == 1:
+            return next(iter(errors))
+        return None
 
     def __str__(self) -> str:
         return self.display()


### PR DESCRIPTION
Planning to add a feature that will use this.
