### PR TITLE
Be more paranoid with attribute access on modules

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,7 @@
 
 ## Unreleased
 
+- Fix crash when `getattr()` on a module object throws an error (#603)
 - Fix handling of positional-only arguments using `/` syntax in stubs (#601)
 - Fix bug where objects with a `__call__` method that takes `*args` instead
   of `self` was not considered callable (#600)

--- a/pyanalyze/node_visitor.py
+++ b/pyanalyze/node_visitor.py
@@ -978,7 +978,9 @@ class BaseNodeVisitor(ast.NodeVisitor):
             if module is None:
                 continue
             # ignore compiled modules
-            if not safe_isinstance(safe_getattr(module, "__file__", None), str) or module.__file__.endswith(".so"):
+            if not safe_isinstance(
+                safe_getattr(module, "__file__", None), str
+            ) or module.__file__.endswith(".so"):
                 continue
             if cls._should_ignore_module(module_name):
                 continue

--- a/pyanalyze/node_visitor.py
+++ b/pyanalyze/node_visitor.py
@@ -43,6 +43,7 @@ from ast_decompiler import decompile
 from typing_extensions import NotRequired, Protocol, TypedDict
 
 from . import analysis_lib
+from .safe import safe_getattr, safe_isinstance
 
 Error = Dict[str, Any]
 
@@ -977,7 +978,7 @@ class BaseNodeVisitor(ast.NodeVisitor):
             if module is None:
                 continue
             # ignore compiled modules
-            if not getattr(module, "__file__", None) or module.__file__.endswith(".so"):
+            if not safe_isinstance(safe_getattr(module, "__file__", None), str) or module.__file__.endswith(".so"):
                 continue
             if cls._should_ignore_module(module_name):
                 continue


### PR DESCRIPTION
On some TensorFlow module, getattr(module, "__flle__", None) can throw a TypeError.