### PR TITLE
Fix broken link to "Type System" details in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Some use cases for this tool include:
 - **Catching bugs before they reach production**. The script will catch accidental mistakes like writing "`collections.defalutdict`" instead of "`collections.defaultdict`", so that they won't cause errors in production. Other categories of bugs it can find include variables that may be undefined at runtime, duplicate keys in dict literals, and missing `await` keywords.
 - **Making refactoring easier**. When you make a change like removing an object attribute or moving a class from one file to another, pyanalyze will often be able to flag code that you forgot to change.
 - **Finding dead code**. It has an option for finding Python objects (functions and classes) that are not used anywhere in the codebase.
-- **Checking type annotations**. Type annotations are useful as documentation for readers of code, but only when they are actually correct. Although pyanalyze does not support the full Python type system (see [below](#type-system) for details), it can often detect incorrect type annotations.
+- **Checking type annotations**. Type annotations are useful as documentation for readers of code, but only when they are actually correct. Although pyanalyze does not support the full Python type system (see [here](https://pyanalyze.readthedocs.io/en/latest/typesystem.html) for details), it can often detect incorrect type annotations.
 
 ## Usage
 


### PR DESCRIPTION
Hi.

Just a small fix.
It seems documentation was moved in https://github.com/quora/pyanalyze/commit/14341fcadc26b08c8776296cad2c307aa5171e4f but link was not updated.