### PR TITLE
Improve handling of some string forward references:

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Improve handling of some string forward references (#652)
 - Add hardcoded support for `pytest.raises` to avoid false
   positives (#651)
 - Fix crash with nested classes in stubs. For now, `Any` is

--- a/pyanalyze/arg_spec.py
+++ b/pyanalyze/arg_spec.py
@@ -191,6 +191,8 @@ class AnnotationsContext(Context):
         super().__init__()
 
     def get_name(self, node: ast.Name) -> Value:
+        if self.module is not None:
+            return self.get_name_from_globals(node.id, self.module.__dict__)
         if self.globals is not None:
             return self.get_name_from_globals(node.id, self.globals)
         return self.handle_undefined_name(node.id)

--- a/pyanalyze/attributes.py
+++ b/pyanalyze/attributes.py
@@ -445,6 +445,8 @@ class AnnotationsContext(Context):
         super().__init__()
 
     def get_name(self, node: ast.Name) -> Value:
+        if self.module is not None:
+            return self.get_name_from_globals(node.id, self.module.__dict__)
         try:
             if isinstance(self.cls, types.ModuleType):
                 globals = self.cls.__dict__

--- a/pyanalyze/test_annotations.py
+++ b/pyanalyze/test_annotations.py
@@ -475,6 +475,33 @@ class TestAnnotations(TestNameCheckVisitorBase):
             return []
 
     @assert_passes()
+    def test_nested_forward_ref(self):
+        from typing import List
+
+        def func(x: List["int"]) -> None:
+            pass
+
+        def no_such_type(x: List["doesnt_exist"]) -> None:  # E: undefined_name
+            pass
+
+        def capybara() -> None:
+            func([1])
+            func(["x"])  # E: incompatible_argument
+
+    @skip_before((3, 9))
+    @assert_passes()
+    def test_nested_forward_ref_pep_585(self):
+        def func(x: list["int"]) -> None:
+            pass
+
+        def no_such_type(x: list["doesnt_exist"]) -> None:  # E: undefined_name
+            pass
+
+        def capybara() -> None:
+            func([1])
+            func(["x"])  # E: incompatible_argument
+
+    @assert_passes()
     def test_forward_ref_incompatible(self):
         def f() -> "int":
             return ""  # E: incompatible_return_value


### PR DESCRIPTION
Discovered that similar errors were treated differently with list[]
and List[]. I think we may not need the suppression of undefined names
here any more thanks to some other changes.
