### PR TITLE
feat: pyproject whitelist

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add option to disable all error codes (#659)
 - Show an error on calls to `typing.Any` (#688)
 - Add command-line option `-c`/`--code` to typecheck code from
   the command line (#685)

--- a/pyanalyze/options.py
+++ b/pyanalyze/options.py
@@ -394,9 +394,10 @@ def _parse_config_section(
                 "Top-level configuration should not set module option"
             )
 
+    section = dict(section)
     enabled_error_codes: Set[str] = set()
     all_error_codes: FrozenSet[str] = get_all_error_codes()
-    disable_all_default_error_codes = section.pop("disable_all", None)
+    disable_all_default_error_codes: bool = bool(section.pop("disable_all", False))
 
     for key, value in section.items():
         if key == "module":
@@ -443,7 +444,8 @@ def _parse_config_section(
     if disable_all_default_error_codes:
         if not enabled_error_codes:
             warnings.warn(
-                "All rules were disabled but not a single one was explicitly enabled"
+                "All rules were disabled but not a single one was "
+                "explicitly enabled"
             )
         error_codes_to_disable = all_error_codes - enabled_error_codes
         for error_code in error_codes_to_disable:

--- a/pyanalyze/options.py
+++ b/pyanalyze/options.py
@@ -444,8 +444,7 @@ def _parse_config_section(
     if disable_all_default_error_codes:
         if not enabled_error_codes:
             warnings.warn(
-                "All rules were disabled but not a single one was "
-                "explicitly enabled"
+                "All rules were disabled but not a single one was explicitly enabled"
             )
         error_codes_to_disable = all_error_codes - enabled_error_codes
         for error_code in error_codes_to_disable:

--- a/pyanalyze/options.py
+++ b/pyanalyze/options.py
@@ -445,7 +445,7 @@ def _parse_config_section(
             warnings.warn(
                 "All rules were disabled but not a single one was explicitly enabled"
             )
-        error_codes_to_disable = get_all_error_codes() - enabled_error_codes
+        error_codes_to_disable = all_error_codes - enabled_error_codes
         for error_code in error_codes_to_disable:
             option_cls = ConfigOption.registry[error_code]
             yield option_cls(option_cls.parse(False, path), module_path)

--- a/pyanalyze/options.py
+++ b/pyanalyze/options.py
@@ -4,8 +4,10 @@ Structured configuration options.
 
 """
 import argparse
+import functools
 import pathlib
 import sys
+import warnings
 from collections import defaultdict
 from dataclasses import dataclass
 from pathlib import Path
@@ -14,11 +16,13 @@ from typing import (
     ClassVar,
     Collection,
     Dict,
+    FrozenSet,
     Generic,
     Iterable,
     Mapping,
     Optional,
     Sequence,
+    Set,
     Tuple,
     Type,
     TypeVar,
@@ -371,6 +375,11 @@ def parse_config_file(
     )
 
 
+@functools.lru_cache
+def get_all_error_codes() -> FrozenSet[str]:
+    return frozenset({error_code.name for error_code in ErrorCode})
+
+
 def _parse_config_section(
     section: Mapping[str, Any],
     module_path: ModulePath = (),
@@ -384,6 +393,11 @@ def _parse_config_section(
             raise InvalidConfigOption(
                 "Top-level configuration should not set module option"
             )
+
+    enabled_error_codes: Set[str] = set()
+    all_error_codes: FrozenSet[str] = get_all_error_codes()
+    disable_all_default_error_codes = section.pop("disable_all", None)
+
     for key, value in section.items():
         if key == "module":
             if module_path == ():
@@ -422,4 +436,16 @@ def _parse_config_section(
                 option_cls = ConfigOption.registry[key]
             except KeyError:
                 raise InvalidConfigOption(f"Invalid configuration option {key!r}")
+            if isinstance(value, bool) and key in all_error_codes and value is True:
+                enabled_error_codes.add(key)
             yield option_cls(option_cls.parse(value, path), module_path)
+
+    if disable_all_default_error_codes:
+        if not enabled_error_codes:
+            warnings.warn(
+                "All rules were disabled but not a single one was explicitly enabled"
+            )
+        error_codes_to_disable = get_all_error_codes() - enabled_error_codes
+        for error_code in error_codes_to_disable:
+            option_cls = ConfigOption.registry[error_code]
+            yield option_cls(option_cls.parse(False, path), module_path)


### PR DESCRIPTION
This PR implements the "white-list" feature for `pyproject.toml`. Adding `disable-all = true` will automatically disable all rules but the ones indicated in the `pyproject.toml`. While I was doing it, I thought that maybe `disable-all-default-rules` would be more explicit, but I left the `disable_all` to be more consistent with the CLI implementation.

Regarding the tests, tell me if it is needed to write some.

About the implementation itself, maybe there might be better ways of doing. Specially for the function that gets all error codes. Maybe there is a util-based function that already does that.

Linked to #648 