### PR TITLE
Revert "Fix name mangling (#658)"

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,7 +4,6 @@
 
 - Support classes that set a `__signature__` attribute to
   define their constructor signature (such as Pydantic models) (#665)
-- Handle mangling of private attribute names (#658)
 - Declare support for Python 3.12. Not all new features in
   Python 3.12 are supported yet. (#656)
 - Fix treatment of `@property` by the `incompatible_override`

--- a/pyanalyze/test_attributes.py
+++ b/pyanalyze/test_attributes.py
@@ -317,38 +317,6 @@ class TestAttributes(TestNameCheckVisitorBase):
             c = C()
             assert_is_value(c.f(), TypedValue(int))
 
-    @assert_passes()
-    def test_mangling(self):
-        from typing_extensions import assert_type
-
-        class A:
-            __private: int
-
-            def __func(self) -> int:
-                return 0
-
-            def run(self) -> None:
-                assert_type(self.__func(), int)
-                assert_type(self._A__func(), int)
-                assert_type(self.__private, int)
-
-    @assert_passes()
-    def test_mangling_dataclass(self):
-        from dataclasses import dataclass
-        from typing_extensions import assert_type
-
-        @dataclass
-        class A:
-            __private: int
-
-            def __func(self) -> str:
-                return ""
-
-            def run(self) -> None:
-                assert_type(self.__func(), str)
-                assert_type(self._A__func(), str)
-                assert_type(self.__private, int)
-
 
 class TestHasAttrExtension(TestNameCheckVisitorBase):
     @assert_passes()


### PR DESCRIPTION
This reverts commit b3d2824f7ce9c6ca3ff6cb58f6f7f7c8ecacb2d3.

Seems to have caused a performance regression.