### PR TITLE
Support for annotated_types

### DIFF
--- a/docs/annotated_types.md
+++ b/docs/annotated_types.md
@@ -2,6 +2,42 @@
 
 Pyanalyze supports the [annotated-types](https://pypi.org/project/annotated-types/) library, which provides a set of common primitives to use in `Annotated` metadata.
 
+This is useful for restricting the value of an object:
+
+```python
+from typing_extensions import Annotated
+from annotated_types import Gt
+
+def takes_gt_5(x: Annotated[int, Gt(5)]) -> None:
+    assert x > 5, "number too small"
+
+def caller() -> None:
+    takes_gt_5(6)  # ok
+    takes_gt_5(5)  # type checker error
+```
+
+Pyanalyze enforces these annotations strictly: if it cannot determine whether or
+not a value fulfills the predicate, it shows an error. For example, the following
+will be rejected:
+
+```python
+def caller(i: int) -> None:
+    takes_gt_5(i)  # type checker error, as it may be less than 5
+```
+
+## Notes on specific predicates
+
+Pyanalyze infers the interval attributes `Gt`, `Ge`, `Lt`, and `Le` based
+on comparisons with literals:
+
+```python
+def caller(i: int) -> None:
+    takes_gt_5(i)  # error
+
+    if i > 5:
+        takes_gt_5(i)  # accepted
+```
+
 For the `MultipleOf` check, pyanalyze follows Python semantics: values
 are accepted if `value % multiple_of == 0`.
 

--- a/docs/annotated_types.md
+++ b/docs/annotated_types.md
@@ -1,0 +1,8 @@
+# Support for `annotated_types`
+
+Pyanalyze supports the [annotated-types](https://pypi.org/project/annotated-types/) library, which provides a set of common primitives to use in `Annotated` metadata.
+
+For the `MultipleOf` check, pyanalyze follows Python semantics: values
+are accepted if `value % multiple_of == 0`.
+
+For the `Timezone` check, support for requiring string-based timezones is not implemented.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Support for annotations from the `annotated-types` library (#673)
 - Detect undefined attributes on Pydantic models (#670)
 - Remove duplicate "attribute_is_never_set" error for classes
   with predefined attributes (#670)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,6 +15,7 @@ pyanalyze: A semi-static typechecker
    typesystem
    design
    type_evaluation
+   annotated_types
    glossary
    reference/annotations
    reference/ast_annotator

--- a/pyanalyze/__init__.py
+++ b/pyanalyze/__init__.py
@@ -8,6 +8,7 @@ pyanalyze is a package for Python static analysis.
 
 from . import (
     analysis_lib,
+    annotated_types,
     annotations,
     arg_spec,
     ast_annotator,
@@ -64,3 +65,4 @@ used(shared_options)
 used(functions)
 used(predicates)
 used(typevar)
+used(annotated_types)

--- a/pyanalyze/annotated_types.py
+++ b/pyanalyze/annotated_types.py
@@ -240,7 +240,7 @@ class MaxLen(AnnotatedTypesCheck):
 
 @dataclass(frozen=True)
 class Timezone(AnnotatedTypesCheck):
-    value: Union[str, timezone, Literal[None, ...]]
+    value: Union[str, timezone, type(...), None]
 
     def predicate(self, value: Any) -> bool:
         if not isinstance(value, datetime):

--- a/pyanalyze/annotated_types.py
+++ b/pyanalyze/annotated_types.py
@@ -146,7 +146,7 @@ class Ge(AnnotatedTypesCheck):
 
     def is_compatible_metadata(self, metadata: AnnotatedTypesCheck) -> bool:
         if isinstance(metadata, Gt):
-            return metadata.value > self.value
+            return metadata.value >= self.value
         elif isinstance(metadata, Ge):
             return metadata.value >= self.value
         else:
@@ -178,7 +178,7 @@ class Le(AnnotatedTypesCheck):
 
     def is_compatible_metadata(self, metadata: AnnotatedTypesCheck) -> bool:
         if isinstance(metadata, Lt):
-            return metadata.value < self.value
+            return metadata.value <= self.value
         elif isinstance(metadata, Le):
             return metadata.value <= self.value
         else:

--- a/pyanalyze/annotated_types.py
+++ b/pyanalyze/annotated_types.py
@@ -6,7 +6,6 @@ Support for annotations from the annotated_types library.
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Callable, Iterable, Optional, Union
-from typing_extensions import Literal
 
 from pyanalyze.value import CanAssign, CanAssignContext, Value, flatten_values
 

--- a/pyanalyze/annotated_types.py
+++ b/pyanalyze/annotated_types.py
@@ -69,7 +69,7 @@ else:
             return None
 
 
-@dataclass
+@dataclass(frozen=True)
 class AnnotatedTypesCheck(CustomCheck):
     def can_assign(self, value: Value, ctx: CanAssignContext) -> CanAssign:
         for subval in flatten_values(value):
@@ -119,7 +119,7 @@ class AnnotatedTypesCheck(CustomCheck):
         )
 
 
-@dataclass
+@dataclass(frozen=True)
 class Gt(AnnotatedTypesCheck):
     value: Any
 
@@ -135,7 +135,7 @@ class Gt(AnnotatedTypesCheck):
             return False
 
 
-@dataclass
+@dataclass(frozen=True)
 class Ge(AnnotatedTypesCheck):
     value: Any
 
@@ -151,7 +151,7 @@ class Ge(AnnotatedTypesCheck):
             return False
 
 
-@dataclass
+@dataclass(frozen=True)
 class Lt(AnnotatedTypesCheck):
     value: Any
 
@@ -167,7 +167,7 @@ class Lt(AnnotatedTypesCheck):
             return False
 
 
-@dataclass
+@dataclass(frozen=True)
 class Le(AnnotatedTypesCheck):
     value: Any
 
@@ -183,7 +183,7 @@ class Le(AnnotatedTypesCheck):
             return False
 
 
-@dataclass
+@dataclass(frozen=True)
 class MultipleOf(AnnotatedTypesCheck):
     value: Any
 
@@ -198,7 +198,7 @@ class MultipleOf(AnnotatedTypesCheck):
             return False
 
 
-@dataclass
+@dataclass(frozen=True)
 class MinLen(AnnotatedTypesCheck):
     value: Any
 
@@ -218,7 +218,7 @@ class MinLen(AnnotatedTypesCheck):
         return super().can_assign_non_literal(value)
 
 
-@dataclass
+@dataclass(frozen=True)
 class MaxLen(AnnotatedTypesCheck):
     value: Any
 
@@ -238,7 +238,7 @@ class MaxLen(AnnotatedTypesCheck):
         return super().can_assign_non_literal(value)
 
 
-@dataclass
+@dataclass(frozen=True)
 class Timezone(AnnotatedTypesCheck):
     value: Union[str, timezone, Literal[None, ...]]
 
@@ -264,7 +264,7 @@ class Timezone(AnnotatedTypesCheck):
         return False
 
 
-@dataclass
+@dataclass(frozen=True)
 class Predicate(AnnotatedTypesCheck):
     predicate_callable: Callable[[Any], bool]
 

--- a/pyanalyze/annotated_types.py
+++ b/pyanalyze/annotated_types.py
@@ -1,0 +1,303 @@
+"""
+
+Support for annotations from the annotated_types library.
+
+"""
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Callable, Iterable, Optional, Union
+from typing_extensions import Literal
+
+from annotated_types import BaseMetadata
+
+from pyanalyze.value import CanAssign, CanAssignContext, Value, flatten_values
+
+from .extensions import CustomCheck
+from .value import (
+    AnnotatedValue,
+    AnyValue,
+    CanAssignError,
+    CustomCheckExtension,
+    DictIncompleteValue,
+    KnownValue,
+    SequenceValue,
+    TypedDictValue,
+    unannotate,
+)
+
+try:
+    import annotated_types
+except ImportError:
+
+    def get_annotated_types_extension(obj: object) -> Iterable[CustomCheckExtension]:
+        return []
+
+else:
+
+    def get_annotated_types_extension(obj: object) -> Iterable[CustomCheckExtension]:
+        if not isinstance(obj, annotated_types.BaseMetadata):
+            return
+        if isinstance(obj, annotated_types.GroupedMetadata):
+            for value in obj:
+                maybe_ext = _get_single_annotated_types_extension(value)
+                if maybe_ext is not None:
+                    yield CustomCheckExtension(maybe_ext)
+        else:
+            maybe_ext = _get_single_annotated_types_extension(obj)
+            if maybe_ext is not None:
+                yield CustomCheckExtension(maybe_ext)
+
+    def _get_single_annotated_types_extension(
+        obj: annotated_types.BaseMetadata,
+    ) -> Optional[CustomCheck]:
+        if isinstance(obj, annotated_types.Gt):
+            return GtCheck(obj, obj.gt)
+        elif isinstance(obj, annotated_types.Ge):
+            return GeCheck(obj, obj.ge)
+        elif isinstance(obj, annotated_types.Lt):
+            return LtCheck(obj, obj.lt)
+        elif isinstance(obj, annotated_types.Le):
+            return LeCheck(obj, obj.le)
+        elif isinstance(obj, annotated_types.MultipleOf):
+            return MultipleOfCheck(obj, obj.multiple_of)
+        elif isinstance(obj, annotated_types.MinLen):
+            return MinLenCheck(obj, obj.min_length)
+        elif isinstance(obj, annotated_types.MaxLen):
+            return MaxLenCheck(obj, obj.max_length)
+        elif isinstance(obj, annotated_types.Timezone):
+            return TimezoneCheck(obj, obj.tz)
+        elif isinstance(obj, annotated_types.Predicate):
+            return PredicateCheck(obj, obj.func)
+        else:
+            # In case annotated_types adds more kinds of checks in the future
+            return None
+
+    @dataclass
+    class AnnotatedTypesCheck(CustomCheck):
+        metadata: annotated_types.BaseMetadata
+
+        def can_assign(self, value: Value, ctx: CanAssignContext) -> CanAssign:
+            for subval in flatten_values(value):
+                original_subval = subval
+                if isinstance(subval, AnnotatedValue):
+                    if any(
+                        ext.metadata == self.metadata
+                        or self.is_compatible_metadata(ext.metadata)
+                        for ext in subval.get_custom_check_of_type(AnnotatedTypesCheck)
+                    ):
+                        continue
+                subval = unannotate(subval)
+                if isinstance(subval, AnyValue):
+                    continue
+                if isinstance(subval, KnownValue):
+                    try:
+                        result = self.predicate(subval.val)
+                    except Exception:
+                        return CanAssignError(
+                            f"Value {subval.val} cannot be checked against predicate"
+                            f" {self.metadata}"
+                        )
+                    else:
+                        if not result:
+                            return CanAssignError(
+                                f"Value {subval.val} does not match predicate"
+                                f" {self.metadata}"
+                            )
+                else:
+                    can_assign = self.can_assign_non_literal(original_subval)
+                    if isinstance(can_assign, CanAssignError):
+                        return can_assign
+            return {}
+
+        def predicate(self, value: Any) -> bool:
+            raise NotImplementedError
+
+        def is_compatible_metadata(self, metadata: BaseMetadata) -> bool:
+            """Override this to allow metadata that is not exactly the same as the
+            one in this object to match. For example, Gt(5) should accept Gt(4), as that
+            is a strictly weaker condition.
+            """
+            return False
+
+        def can_assign_non_literal(self, value: Value) -> CanAssign:
+            """Override this to allow some non-Literal values. For example, the
+            MinLen extensions can allow sequences with sufficiently known lengths."""
+            return CanAssignError(
+                f"Cannot determine whether {value} fulfills predicate {self.metadata}"
+            )
+
+    @dataclass
+    class GtCheck(AnnotatedTypesCheck):
+        value: Any
+
+        def predicate(self, value: Any) -> bool:
+            return value > self.value
+
+        def is_compatible_metadata(self, metadata: BaseMetadata) -> bool:
+            if isinstance(metadata, annotated_types.Gt):
+                return metadata.gt >= self.value
+            elif isinstance(metadata, annotated_types.Ge):
+                return metadata.ge > self.value
+            else:
+                return False
+
+    @dataclass
+    class GeCheck(AnnotatedTypesCheck):
+        value: Any
+
+        def predicate(self, value: Any) -> bool:
+            return value >= self.value
+
+        def is_compatible_metadata(self, metadata: BaseMetadata) -> bool:
+            if isinstance(metadata, annotated_types.Gt):
+                return metadata.gt > self.value
+            elif isinstance(metadata, annotated_types.Ge):
+                return metadata.ge >= self.value
+            else:
+                return False
+
+    @dataclass
+    class LtCheck(AnnotatedTypesCheck):
+        value: Any
+
+        def predicate(self, value: Any) -> bool:
+            return value < self.value
+
+        def is_compatible_metadata(self, metadata: BaseMetadata) -> bool:
+            if isinstance(metadata, annotated_types.Lt):
+                return metadata.lt <= self.value
+            elif isinstance(metadata, annotated_types.Le):
+                return metadata.le < self.value
+            else:
+                return False
+
+    @dataclass
+    class LeCheck(AnnotatedTypesCheck):
+        value: Any
+
+        def predicate(self, value: Any) -> bool:
+            return value <= self.value
+
+        def is_compatible_metadata(self, metadata: BaseMetadata) -> bool:
+            if isinstance(metadata, annotated_types.Lt):
+                return metadata.lt < self.value
+            elif isinstance(metadata, annotated_types.Le):
+                return metadata.le <= self.value
+            else:
+                return False
+
+    @dataclass
+    class MultipleOfCheck(AnnotatedTypesCheck):
+        value: Any
+
+        def predicate(self, value: Any) -> bool:
+            return value % self.value == 0
+
+        def is_compatible_metadata(self, metadata: BaseMetadata) -> bool:
+            if isinstance(metadata, annotated_types.MultipleOf):
+                # If we want a MultipleOf(10), but we're passed a MultipleOf(5), that's ok
+                return self.value % metadata.multiple_of == 0
+            else:
+                return False
+
+    @dataclass
+    class MinLenCheck(AnnotatedTypesCheck):
+        value: Any
+
+        def predicate(self, value: Any) -> bool:
+            return len(value) >= self.value
+
+        def is_compatible_metadata(self, metadata: BaseMetadata) -> bool:
+            if isinstance(metadata, annotated_types.MinLen):
+                return metadata.min_length <= self.value
+            else:
+                return False
+
+        def can_assign_non_literal(self, value: Value) -> CanAssign:
+            min_len = _min_len_of_value(value)
+            if min_len is not None and min_len >= self.value:
+                return {}
+            return super().can_assign_non_literal(value)
+
+    @dataclass
+    class MaxLenCheck(AnnotatedTypesCheck):
+        value: Any
+
+        def predicate(self, value: Any) -> bool:
+            return len(value) <= self.value
+
+        def is_compatible_metadata(self, metadata: BaseMetadata) -> bool:
+            if isinstance(metadata, annotated_types.MaxLen):
+                return metadata.max_length >= self.value
+            else:
+                return False
+
+        def can_assign_non_literal(self, value: Value) -> CanAssign:
+            max_len = _max_len_of_value(value)
+            if max_len is not None and max_len <= self.value:
+                return {}
+            return super().can_assign_non_literal(value)
+
+    @dataclass
+    class TimezoneCheck(AnnotatedTypesCheck):
+        value: Union[str, timezone, Literal[None, ...]]
+
+        def predicate(self, value: Any) -> bool:
+            if not isinstance(value, datetime):
+                return False
+            if self.value is None:
+                return value.tzinfo is None
+            elif self.value is ...:
+                return value.tzinfo is not None
+            elif isinstance(self.value, timezone):
+                return value.tzinfo == self.value
+            else:
+                return False
+
+        def is_compatible_metadata(self, metadata: BaseMetadata) -> bool:
+            if (
+                self.value is ...
+                and isinstance(metadata, annotated_types.Timezone)
+                and metadata.value is not None
+            ):
+                return True
+            return False
+
+    @dataclass
+    class PredicateCheck(AnnotatedTypesCheck):
+        predicate_callable: Callable[[Any], bool]
+
+        def predicate(self, value: Any) -> bool:
+            return self.predicate_callable(value)
+
+
+def _min_len_of_value(val: Value) -> Optional[int]:
+    if isinstance(val, SequenceValue):
+        return sum(is_many is False for is_many, _ in val.members)
+    elif isinstance(val, DictIncompleteValue):
+        return sum(pair.is_required and not pair.is_many for pair in val.kv_pairs)
+    elif isinstance(val, TypedDictValue):
+        return sum(required for required, _ in val.items.values())
+    else:
+        return None
+
+
+def _max_len_of_value(val: Value) -> Optional[int]:
+    if isinstance(val, SequenceValue):
+        maximum = 0
+        for is_many, _ in val.members:
+            if is_many:
+                return None
+            maximum += 1
+        return maximum
+    elif isinstance(val, DictIncompleteValue):
+        maximum = 0
+        for pair in val.kv_pairs:
+            if pair.is_many:
+                return None
+            if pair.is_required:
+                maximum += 1
+        return maximum
+    else:
+        # Always None for TypedDicts as TypedDicts may have arbitrary extra keys
+        return None

--- a/pyanalyze/annotated_types.py
+++ b/pyanalyze/annotated_types.py
@@ -8,8 +8,6 @@ from datetime import datetime, timezone
 from typing import Any, Callable, Iterable, Optional, Union
 from typing_extensions import Literal
 
-from annotated_types import BaseMetadata
-
 from pyanalyze.value import CanAssign, CanAssignContext, Value, flatten_values
 
 from .extensions import CustomCheck
@@ -51,224 +49,229 @@ else:
         obj: annotated_types.BaseMetadata,
     ) -> Optional[CustomCheck]:
         if isinstance(obj, annotated_types.Gt):
-            return GtCheck(obj, obj.gt)
+            return Gt(obj.gt)
         elif isinstance(obj, annotated_types.Ge):
-            return GeCheck(obj, obj.ge)
+            return Ge(obj.ge)
         elif isinstance(obj, annotated_types.Lt):
-            return LtCheck(obj, obj.lt)
+            return Lt(obj.lt)
         elif isinstance(obj, annotated_types.Le):
-            return LeCheck(obj, obj.le)
+            return Le(obj.le)
         elif isinstance(obj, annotated_types.MultipleOf):
-            return MultipleOfCheck(obj, obj.multiple_of)
+            return MultipleOf(obj.multiple_of)
         elif isinstance(obj, annotated_types.MinLen):
-            return MinLenCheck(obj, obj.min_length)
+            return MinLen(obj.min_length)
         elif isinstance(obj, annotated_types.MaxLen):
-            return MaxLenCheck(obj, obj.max_length)
+            return MaxLen(obj.max_length)
         elif isinstance(obj, annotated_types.Timezone):
-            return TimezoneCheck(obj, obj.tz)
+            return Timezone(obj.tz)
         elif isinstance(obj, annotated_types.Predicate):
-            return PredicateCheck(obj, obj.func)
+            return Predicate(obj.func)
         else:
             # In case annotated_types adds more kinds of checks in the future
             return None
 
-    @dataclass
-    class AnnotatedTypesCheck(CustomCheck):
-        metadata: annotated_types.BaseMetadata
 
-        def can_assign(self, value: Value, ctx: CanAssignContext) -> CanAssign:
-            for subval in flatten_values(value):
-                original_subval = subval
-                if isinstance(subval, AnnotatedValue):
-                    if any(
-                        ext.metadata == self.metadata
-                        or self.is_compatible_metadata(ext.metadata)
-                        for ext in subval.get_custom_check_of_type(AnnotatedTypesCheck)
-                    ):
-                        continue
-                subval = unannotate(subval)
-                if isinstance(subval, AnyValue):
+@dataclass
+class AnnotatedTypesCheck(CustomCheck):
+    def can_assign(self, value: Value, ctx: CanAssignContext) -> CanAssign:
+        for subval in flatten_values(value):
+            original_subval = subval
+            if isinstance(subval, AnnotatedValue):
+                if any(
+                    ext == self or self.is_compatible_metadata(ext)
+                    for ext in subval.get_custom_check_of_type(AnnotatedTypesCheck)
+                ):
                     continue
-                if isinstance(subval, KnownValue):
-                    try:
-                        result = self.predicate(subval.val)
-                    except Exception:
-                        return CanAssignError(
-                            f"Value {subval.val} cannot be checked against predicate"
-                            f" {self.metadata}"
-                        )
-                    else:
-                        if not result:
-                            return CanAssignError(
-                                f"Value {subval.val} does not match predicate"
-                                f" {self.metadata}"
-                            )
+            subval = unannotate(subval)
+            if isinstance(subval, AnyValue):
+                continue
+            if isinstance(subval, KnownValue):
+                try:
+                    result = self.predicate(subval.val)
+                except Exception:
+                    return CanAssignError(
+                        f"Value {subval.val} cannot be checked against predicate {self}"
+                    )
                 else:
-                    can_assign = self.can_assign_non_literal(original_subval)
-                    if isinstance(can_assign, CanAssignError):
-                        return can_assign
+                    if not result:
+                        return CanAssignError(
+                            f"Value {subval.val} does not match predicate {self}"
+                        )
+            else:
+                can_assign = self.can_assign_non_literal(original_subval)
+                if isinstance(can_assign, CanAssignError):
+                    return can_assign
+        return {}
+
+    def predicate(self, value: Any) -> bool:
+        raise NotImplementedError
+
+    def is_compatible_metadata(self, metadata: "AnnotatedTypesCheck") -> bool:
+        """Override this to allow metadata that is not exactly the same as the
+        one in this object to match. For example, Gt(5) should accept Gt(4), as that
+        is a strictly weaker condition.
+        """
+        return False
+
+    def can_assign_non_literal(self, value: Value) -> CanAssign:
+        """Override this to allow some non-Literal values. For example, the
+        MinLen extensions can allow sequences with sufficiently known lengths."""
+        return CanAssignError(
+            f"Cannot determine whether {value} fulfills predicate {self}"
+        )
+
+
+@dataclass
+class Gt(AnnotatedTypesCheck):
+    value: Any
+
+    def predicate(self, value: Any) -> bool:
+        return value > self.value
+
+    def is_compatible_metadata(self, metadata: AnnotatedTypesCheck) -> bool:
+        if isinstance(metadata, Gt):
+            return metadata.value >= self.value
+        elif isinstance(metadata, Ge):
+            return metadata.value > self.value
+        else:
+            return False
+
+
+@dataclass
+class Ge(AnnotatedTypesCheck):
+    value: Any
+
+    def predicate(self, value: Any) -> bool:
+        return value >= self.value
+
+    def is_compatible_metadata(self, metadata: AnnotatedTypesCheck) -> bool:
+        if isinstance(metadata, Gt):
+            return metadata.value > self.value
+        elif isinstance(metadata, Ge):
+            return metadata.value >= self.value
+        else:
+            return False
+
+
+@dataclass
+class Lt(AnnotatedTypesCheck):
+    value: Any
+
+    def predicate(self, value: Any) -> bool:
+        return value < self.value
+
+    def is_compatible_metadata(self, metadata: AnnotatedTypesCheck) -> bool:
+        if isinstance(metadata, Lt):
+            return metadata.value <= self.value
+        elif isinstance(metadata, Le):
+            return metadata.value < self.value
+        else:
+            return False
+
+
+@dataclass
+class Le(AnnotatedTypesCheck):
+    value: Any
+
+    def predicate(self, value: Any) -> bool:
+        return value <= self.value
+
+    def is_compatible_metadata(self, metadata: AnnotatedTypesCheck) -> bool:
+        if isinstance(metadata, Lt):
+            return metadata.value < self.value
+        elif isinstance(metadata, Le):
+            return metadata.value <= self.value
+        else:
+            return False
+
+
+@dataclass
+class MultipleOf(AnnotatedTypesCheck):
+    value: Any
+
+    def predicate(self, value: Any) -> bool:
+        return value % self.value == 0
+
+    def is_compatible_metadata(self, metadata: AnnotatedTypesCheck) -> bool:
+        if isinstance(metadata, MultipleOf):
+            # If we want a MultipleOf(10), but we're passed a MultipleOf(5), that's ok
+            return self.value % metadata.value == 0
+        else:
+            return False
+
+
+@dataclass
+class MinLen(AnnotatedTypesCheck):
+    value: Any
+
+    def predicate(self, value: Any) -> bool:
+        return len(value) >= self.value
+
+    def is_compatible_metadata(self, metadata: AnnotatedTypesCheck) -> bool:
+        if isinstance(metadata, MinLen):
+            return metadata.value >= self.value
+        else:
+            return False
+
+    def can_assign_non_literal(self, value: Value) -> CanAssign:
+        min_len = _min_len_of_value(value)
+        if min_len is not None and min_len >= self.value:
             return {}
+        return super().can_assign_non_literal(value)
 
-        def predicate(self, value: Any) -> bool:
-            raise NotImplementedError
 
-        def is_compatible_metadata(self, metadata: BaseMetadata) -> bool:
-            """Override this to allow metadata that is not exactly the same as the
-            one in this object to match. For example, Gt(5) should accept Gt(4), as that
-            is a strictly weaker condition.
-            """
+@dataclass
+class MaxLen(AnnotatedTypesCheck):
+    value: Any
+
+    def predicate(self, value: Any) -> bool:
+        return len(value) <= self.value
+
+    def is_compatible_metadata(self, metadata: AnnotatedTypesCheck) -> bool:
+        if isinstance(metadata, MaxLen):
+            return metadata.value <= self.value
+        else:
             return False
 
-        def can_assign_non_literal(self, value: Value) -> CanAssign:
-            """Override this to allow some non-Literal values. For example, the
-            MinLen extensions can allow sequences with sufficiently known lengths."""
-            return CanAssignError(
-                f"Cannot determine whether {value} fulfills predicate {self.metadata}"
-            )
+    def can_assign_non_literal(self, value: Value) -> CanAssign:
+        max_len = _max_len_of_value(value)
+        if max_len is not None and max_len <= self.value:
+            return {}
+        return super().can_assign_non_literal(value)
 
-    @dataclass
-    class GtCheck(AnnotatedTypesCheck):
-        value: Any
 
-        def predicate(self, value: Any) -> bool:
-            return value > self.value
+@dataclass
+class Timezone(AnnotatedTypesCheck):
+    value: Union[str, timezone, Literal[None, ...]]
 
-        def is_compatible_metadata(self, metadata: BaseMetadata) -> bool:
-            if isinstance(metadata, annotated_types.Gt):
-                return metadata.gt >= self.value
-            elif isinstance(metadata, annotated_types.Ge):
-                return metadata.ge > self.value
-            else:
-                return False
-
-    @dataclass
-    class GeCheck(AnnotatedTypesCheck):
-        value: Any
-
-        def predicate(self, value: Any) -> bool:
-            return value >= self.value
-
-        def is_compatible_metadata(self, metadata: BaseMetadata) -> bool:
-            if isinstance(metadata, annotated_types.Gt):
-                return metadata.gt > self.value
-            elif isinstance(metadata, annotated_types.Ge):
-                return metadata.ge >= self.value
-            else:
-                return False
-
-    @dataclass
-    class LtCheck(AnnotatedTypesCheck):
-        value: Any
-
-        def predicate(self, value: Any) -> bool:
-            return value < self.value
-
-        def is_compatible_metadata(self, metadata: BaseMetadata) -> bool:
-            if isinstance(metadata, annotated_types.Lt):
-                return metadata.lt <= self.value
-            elif isinstance(metadata, annotated_types.Le):
-                return metadata.le < self.value
-            else:
-                return False
-
-    @dataclass
-    class LeCheck(AnnotatedTypesCheck):
-        value: Any
-
-        def predicate(self, value: Any) -> bool:
-            return value <= self.value
-
-        def is_compatible_metadata(self, metadata: BaseMetadata) -> bool:
-            if isinstance(metadata, annotated_types.Lt):
-                return metadata.lt < self.value
-            elif isinstance(metadata, annotated_types.Le):
-                return metadata.le <= self.value
-            else:
-                return False
-
-    @dataclass
-    class MultipleOfCheck(AnnotatedTypesCheck):
-        value: Any
-
-        def predicate(self, value: Any) -> bool:
-            return value % self.value == 0
-
-        def is_compatible_metadata(self, metadata: BaseMetadata) -> bool:
-            if isinstance(metadata, annotated_types.MultipleOf):
-                # If we want a MultipleOf(10), but we're passed a MultipleOf(5), that's ok
-                return self.value % metadata.multiple_of == 0
-            else:
-                return False
-
-    @dataclass
-    class MinLenCheck(AnnotatedTypesCheck):
-        value: Any
-
-        def predicate(self, value: Any) -> bool:
-            return len(value) >= self.value
-
-        def is_compatible_metadata(self, metadata: BaseMetadata) -> bool:
-            if isinstance(metadata, annotated_types.MinLen):
-                return metadata.min_length <= self.value
-            else:
-                return False
-
-        def can_assign_non_literal(self, value: Value) -> CanAssign:
-            min_len = _min_len_of_value(value)
-            if min_len is not None and min_len >= self.value:
-                return {}
-            return super().can_assign_non_literal(value)
-
-    @dataclass
-    class MaxLenCheck(AnnotatedTypesCheck):
-        value: Any
-
-        def predicate(self, value: Any) -> bool:
-            return len(value) <= self.value
-
-        def is_compatible_metadata(self, metadata: BaseMetadata) -> bool:
-            if isinstance(metadata, annotated_types.MaxLen):
-                return metadata.max_length >= self.value
-            else:
-                return False
-
-        def can_assign_non_literal(self, value: Value) -> CanAssign:
-            max_len = _max_len_of_value(value)
-            if max_len is not None and max_len <= self.value:
-                return {}
-            return super().can_assign_non_literal(value)
-
-    @dataclass
-    class TimezoneCheck(AnnotatedTypesCheck):
-        value: Union[str, timezone, Literal[None, ...]]
-
-        def predicate(self, value: Any) -> bool:
-            if not isinstance(value, datetime):
-                return False
-            if self.value is None:
-                return value.tzinfo is None
-            elif self.value is ...:
-                return value.tzinfo is not None
-            elif isinstance(self.value, timezone):
-                return value.tzinfo == self.value
-            else:
-                return False
-
-        def is_compatible_metadata(self, metadata: BaseMetadata) -> bool:
-            if (
-                self.value is ...
-                and isinstance(metadata, annotated_types.Timezone)
-                and metadata.value is not None
-            ):
-                return True
+    def predicate(self, value: Any) -> bool:
+        if not isinstance(value, datetime):
+            return False
+        if self.value is None:
+            return value.tzinfo is None
+        elif self.value is ...:
+            return value.tzinfo is not None
+        elif isinstance(self.value, timezone):
+            return value.tzinfo == self.value
+        else:
             return False
 
-    @dataclass
-    class PredicateCheck(AnnotatedTypesCheck):
-        predicate_callable: Callable[[Any], bool]
+    def is_compatible_metadata(self, metadata: AnnotatedTypesCheck) -> bool:
+        if (
+            self.value is ...
+            and isinstance(metadata, Timezone)
+            and metadata.value is not None
+        ):
+            return True
+        return False
 
-        def predicate(self, value: Any) -> bool:
-            return self.predicate_callable(value)
+
+@dataclass
+class Predicate(AnnotatedTypesCheck):
+    predicate_callable: Callable[[Any], bool]
+
+    def predicate(self, value: Any) -> bool:
+        return self.predicate_callable(value)
 
 
 def _min_len_of_value(val: Value) -> Optional[int]:

--- a/pyanalyze/annotated_types.py
+++ b/pyanalyze/annotated_types.py
@@ -33,14 +33,12 @@ except ImportError:
 else:
 
     def get_annotated_types_extension(obj: object) -> Iterable[CustomCheckExtension]:
-        if not isinstance(obj, annotated_types.BaseMetadata):
-            return
         if isinstance(obj, annotated_types.GroupedMetadata):
             for value in obj:
                 maybe_ext = _get_single_annotated_types_extension(value)
                 if maybe_ext is not None:
                     yield CustomCheckExtension(maybe_ext)
-        else:
+        elif isinstance(obj, annotated_types.BaseMetadata):
             maybe_ext = _get_single_annotated_types_extension(obj)
             if maybe_ext is not None:
                 yield CustomCheckExtension(maybe_ext)
@@ -194,8 +192,8 @@ class MultipleOf(AnnotatedTypesCheck):
 
     def is_compatible_metadata(self, metadata: AnnotatedTypesCheck) -> bool:
         if isinstance(metadata, MultipleOf):
-            # If we want a MultipleOf(10), but we're passed a MultipleOf(5), that's ok
-            return self.value % metadata.value == 0
+            # If we want a MultipleOf(5), but we're passed a MultipleOf(10), that's ok
+            return metadata.value % self.value == 0
         else:
             return False
 

--- a/pyanalyze/annotations.py
+++ b/pyanalyze/annotations.py
@@ -51,6 +51,8 @@ import qcore
 
 from typing_extensions import ParamSpec, TypedDict, get_origin, get_args
 
+from pyanalyze.annotated_types import get_annotated_types_extension
+
 from . import type_evaluation
 
 from .error_code import ErrorCode
@@ -1278,29 +1280,43 @@ def _make_callable_from_value(
 
 
 def _make_annotated(origin: Value, metadata: Sequence[Value], ctx: Context) -> Value:
-    metadata = [_value_from_metadata(entry, ctx) for entry in metadata]
-    return annotate_value(origin, metadata)
-
-
-def _value_from_metadata(entry: Value, ctx: Context) -> Union[Value, Extension]:
-    if isinstance(entry, KnownValue):
-        if isinstance(entry.val, ParameterTypeGuard):
-            return ParameterTypeGuardExtension(
-                entry.val.varname, _type_from_runtime(entry.val.guarded_type, ctx)
-            )
-        elif isinstance(entry.val, NoReturnGuard):
-            return NoReturnGuardExtension(
-                entry.val.varname, _type_from_runtime(entry.val.guarded_type, ctx)
-            )
-        elif isinstance(entry.val, HasAttrGuard):
-            return HasAttrGuardExtension(
-                entry.val.varname,
-                _type_from_runtime(entry.val.attribute_name, ctx),
-                _type_from_runtime(entry.val.attribute_type, ctx),
-            )
-        elif isinstance(entry.val, CustomCheck):
-            return CustomCheckExtension(entry.val)
-    return entry
+    metadata_objs: list[Union[Value, Extension]] = []
+    for entry in metadata:
+        if isinstance(entry, KnownValue):
+            if isinstance(entry.val, ParameterTypeGuard):
+                metadata_objs.append(
+                    ParameterTypeGuardExtension(
+                        entry.val.varname,
+                        _type_from_runtime(entry.val.guarded_type, ctx),
+                    )
+                )
+                continue
+            elif isinstance(entry.val, NoReturnGuard):
+                metadata_objs.append(
+                    NoReturnGuardExtension(
+                        entry.val.varname,
+                        _type_from_runtime(entry.val.guarded_type, ctx),
+                    )
+                )
+                continue
+            elif isinstance(entry.val, HasAttrGuard):
+                metadata_objs.append(
+                    HasAttrGuardExtension(
+                        entry.val.varname,
+                        _type_from_runtime(entry.val.attribute_name, ctx),
+                        _type_from_runtime(entry.val.attribute_type, ctx),
+                    )
+                )
+                continue
+            elif isinstance(entry.val, CustomCheck):
+                metadata_objs.append(CustomCheckExtension(entry.val))
+                continue
+            annotated_types_extensions = list(get_annotated_types_extension(entry.val))
+            if annotated_types_extensions:
+                metadata_objs.extend(annotated_types_extensions)
+            else:
+                metadata_objs.append(entry)
+    return annotate_value(origin, metadata_objs)
 
 
 _CONTEXT_MANAGER_TYPES = {

--- a/pyanalyze/annotations.py
+++ b/pyanalyze/annotations.py
@@ -23,7 +23,6 @@ These functions all use :class:`Context` objects to resolve names and
 show errors.
 
 """
-from _ast import Dict
 import ast
 import builtins
 import contextlib
@@ -36,6 +35,7 @@ from typing import (
     Container,
     ContextManager,
     Generator,
+    List,
     Mapping,
     NewType,
     Optional,
@@ -926,7 +926,7 @@ class _Visitor(ast.NodeVisitor):
         elts = [(False, self.visit(elt)) for elt in node.elts]
         return SequenceValue(set, elts)
 
-    def visit_Dict(self, node: Dict) -> Any:
+    def visit_Dict(self, node: ast.Dict) -> Any:
         keys = [self.visit(key) if key is not None else None for key in node.keys]
         values = [self.visit(value) for value in node.values]
         kvpairs = []
@@ -1280,7 +1280,7 @@ def _make_callable_from_value(
 
 
 def _make_annotated(origin: Value, metadata: Sequence[Value], ctx: Context) -> Value:
-    metadata_objs: list[Union[Value, Extension]] = []
+    metadata_objs: List[Union[Value, Extension]] = []
     for entry in metadata:
         if isinstance(entry, KnownValue):
             if isinstance(entry.val, ParameterTypeGuard):

--- a/pyanalyze/name_check_visitor.py
+++ b/pyanalyze/name_check_visitor.py
@@ -3351,7 +3351,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                         if not result:
                             return None
                     return value
-                if ext is not None:
+                if ext is not None and positive:
                     return annotate_value(value, [CustomCheckExtension(ext(other_val))])
                 return value
 

--- a/pyanalyze/name_check_visitor.py
+++ b/pyanalyze/name_check_visitor.py
@@ -52,6 +52,8 @@ import qcore
 import typeshed_client
 from typing_extensions import Annotated, Protocol, get_args, get_origin
 
+from pyanalyze.annotated_types import Gt, Ge, Le, Lt
+
 from . import attributes, format_strings, importer, node_visitor, type_evaluation
 from .analysis_lib import get_attribute_path
 from .annotations import (
@@ -156,6 +158,7 @@ from .value import (
     SYS_PLATFORM_EXTENSION,
     SYS_VERSION_INFO_EXTENSION,
     AlwaysPresentExtension,
+    CustomCheckExtension,
     DefiniteValueExtension,
     DeprecatedExtension,
     SkipDeprecatedExtension,
@@ -293,16 +296,16 @@ def _not_in(a: object, b: Container[object]) -> bool:
 
 
 COMPARATOR_TO_OPERATOR = {
-    ast.Eq: (operator.eq, operator.ne),
-    ast.NotEq: (operator.ne, operator.eq),
-    ast.Lt: (operator.lt, operator.ge),
-    ast.LtE: (operator.le, operator.gt),
-    ast.Gt: (operator.gt, operator.le),
-    ast.GtE: (operator.ge, operator.lt),
-    ast.Is: (operator.is_, operator.is_not),
-    ast.IsNot: (operator.is_not, operator.is_),
-    ast.In: (_in, _not_in),
-    ast.NotIn: (_not_in, _in),
+    ast.Eq: (operator.eq, operator.ne, None),
+    ast.NotEq: (operator.ne, operator.eq, None),
+    ast.Lt: (operator.lt, operator.ge, Lt),
+    ast.LtE: (operator.le, operator.gt, Le),
+    ast.Gt: (operator.gt, operator.le, Gt),
+    ast.GtE: (operator.ge, operator.lt, Ge),
+    ast.Is: (operator.is_, operator.is_not, None),
+    ast.IsNot: (operator.is_not, operator.is_, None),
+    ast.In: (_in, _not_in, None),
+    ast.NotIn: (_not_in, _in, None),
 }
 
 SAFE_DECORATORS_FOR_ARGSPEC_TO_RETVAL = [KnownValue(asynq.asynq), KnownValue(property)]
@@ -3242,14 +3245,14 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                 and isinstance(rhs, KnownValue)
                 and isinstance(op, (ast.Eq, ast.NotEq))
             ):
-                op_func, _ = COMPARATOR_TO_OPERATOR[type(op)]
+                op_func, _, _ = COMPARATOR_TO_OPERATOR[type(op)]
                 definite_value = op_func(sys.platform, rhs.val)
             elif (
                 SYS_VERSION_INFO_EXTENSION in lhs.metadata
                 and isinstance(rhs, KnownValue)
                 and isinstance(op, (ast.Gt, ast.GtE, ast.Lt, ast.LtE))
             ):
-                op_func, _ = COMPARATOR_TO_OPERATOR[type(op)]
+                op_func, _, _ = COMPARATOR_TO_OPERATOR[type(op)]
                 definite_value = op_func(sys.version_info, rhs.val)
             lhs = lhs.value
         if isinstance(lhs_constraint, PredicateProvider) and isinstance(
@@ -3332,7 +3335,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
             positive = isinstance(op, ast.In)
             return Constraint(varname, ConstraintType.predicate, positive, predicate)
         else:
-            positive_operator, negative_operator = COMPARATOR_TO_OPERATOR[type(op)]
+            positive_operator, negative_operator, ext = COMPARATOR_TO_OPERATOR[type(op)]
 
             def predicate_func(value: Value, positive: bool) -> Optional[Value]:
                 op = positive_operator if positive else negative_operator
@@ -3347,6 +3350,9 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
                     else:
                         if not result:
                             return None
+                    return value
+                if ext is not None:
+                    return annotate_value(value, [CustomCheckExtension(ext(other_val))])
                 return value
 
             return Constraint(varname, ConstraintType.predicate, True, predicate_func)
@@ -3354,7 +3360,7 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
     def _constraint_from_predicate_provider(
         self, pred: PredicateProvider, other_val: Any, op: ast.AST
     ) -> Constraint:
-        positive_operator, negative_operator = COMPARATOR_TO_OPERATOR[type(op)]
+        positive_operator, negative_operator, _ = COMPARATOR_TO_OPERATOR[type(op)]
 
         def predicate_func(value: Value, positive: bool) -> Optional[Value]:
             predicate_value = pred.provider(value)

--- a/pyanalyze/test_annotated_types.py
+++ b/pyanalyze/test_annotated_types.py
@@ -275,5 +275,7 @@ class TestInferAnnotations(TestNameCheckVisitorBase):
             if i > 5:
                 takes_gt_5(i)
 
+            takes_gt_5(i)  # E: incompatible_argument
+
             if i > 6:
                 takes_gt_5(i)

--- a/pyanalyze/test_annotated_types.py
+++ b/pyanalyze/test_annotated_types.py
@@ -42,3 +42,91 @@ class TestGreaterLesser(TestNameCheckVisitorBase):
             takes_gt_5(5)  # E: incompatible_argument
             takes_gt_5(6)
             takes_gt_5("not an int")  # E: incompatible_argument
+
+    @assert_passes()
+    def test_ge(self):
+        from typing_extensions import Annotated
+        from typing import Any
+        from annotated_types import Ge, Gt
+
+        def takes_ge_5(x: Annotated[Any, Ge(5)]) -> None:
+            pass
+
+        def capybara(
+            i: int,
+            unnannotated,
+            ge_4: Annotated[int, Ge(4)],
+            ge_5: Annotated[int, Ge(5)],
+            ge_6: Annotated[int, Ge(6)],
+            gt_4: Annotated[int, Gt(4)],
+            gt_5: Annotated[int, Gt(5)],
+        ) -> None:
+            takes_ge_5(i)  # E: incompatible_argument
+            takes_ge_5(unnannotated)
+            takes_ge_5(ge_4)  # E: incompatible_argument
+            takes_ge_5(ge_5)
+            takes_ge_5(ge_6)
+            # possibly should be allowed, but what if it's a float?
+            takes_ge_5(gt_4)  # E: incompatible_argument
+            takes_ge_5(gt_5)
+            takes_ge_5(4)  # E: incompatible_argument
+            takes_ge_5(5)
+            takes_ge_5(6)
+
+    @assert_passes()
+    def test_lt(self):
+        from typing_extensions import Annotated
+        from typing import Any
+        from annotated_types import Lt, Le
+
+        def takes_lt_5(x: Annotated[Any, Lt(5)]) -> None:
+            pass
+
+        def capybara(
+            i: int,
+            unnannotated,
+            lt_4: Annotated[int, Lt(4)],
+            lt_5: Annotated[int, Lt(5)],
+            lt_6: Annotated[int, Lt(6)],
+            le_4: Annotated[int, Le(4)],
+            le_5: Annotated[int, Le(5)],
+        ) -> None:
+            takes_lt_5(i)  # E: incompatible_argument
+            takes_lt_5(unnannotated)
+            takes_lt_5(lt_4)
+            takes_lt_5(lt_5)
+            takes_lt_5(lt_6)  # E: incompatible_argument
+            takes_lt_5(le_4)
+            takes_lt_5(le_5)  # E: incompatible_argument
+            takes_lt_5(4)
+            takes_lt_5(5)  # E: incompatible_argument
+
+    @assert_passes()
+    def test_le(self):
+        from typing_extensions import Annotated
+        from typing import Any
+        from annotated_types import Le, Lt
+
+        def takes_le_5(x: Annotated[Any, Le(5)]) -> None:
+            pass
+
+        def capybara(
+            i: int,
+            unnannotated,
+            le_4: Annotated[int, Le(4)],
+            le_5: Annotated[int, Le(5)],
+            le_6: Annotated[int, Le(6)],
+            lt_5: Annotated[int, Lt(5)],
+            lt_6: Annotated[int, Lt(6)],
+        ) -> None:
+            takes_le_5(i)  # E: incompatible_argument
+            takes_le_5(unnannotated)
+            takes_le_5(le_4)
+            takes_le_5(le_5)
+            takes_le_5(le_6)  # E: incompatible_argument
+            takes_le_5(lt_5)
+            # possibly should be allowed, but what if it's a float?
+            takes_le_5(lt_6)  # E: incompatible_argument
+            takes_le_5(4)
+            takes_le_5(5)
+            takes_le_5(6)  # E: incompatible_argument

--- a/pyanalyze/test_annotated_types.py
+++ b/pyanalyze/test_annotated_types.py
@@ -3,7 +3,7 @@ from .test_name_check_visitor import TestNameCheckVisitorBase
 from .test_node_visitor import assert_passes
 
 
-class TestGreaterLesser(TestNameCheckVisitorBase):
+class TestAnnotatedTypesAnnotations(TestNameCheckVisitorBase):
     @assert_passes()
     def test_gt(self):
         from typing_extensions import Annotated
@@ -255,3 +255,25 @@ class TestGreaterLesser(TestNameCheckVisitorBase):
             takes_upper(scream)
             takes_upper("WHY DO YOU ONLY WANT UPPERCASE")
             takes_upper("lowercase")  # E: incompatible_argument
+
+
+class TestInferAnnotations(TestNameCheckVisitorBase):
+    @assert_passes()
+    def test_infer_gt(self):
+        from typing_extensions import Annotated
+        from annotated_types import Gt
+
+        def takes_gt_5(x: Annotated[int, Gt(5)]) -> None:
+            pass
+
+        def capybara(i: int) -> None:
+            takes_gt_5(i)  # E: incompatible_argument
+
+            if i > 4:
+                takes_gt_5(i)  # E: incompatible_argument
+
+            if i > 5:
+                takes_gt_5(i)
+
+            if i > 6:
+                takes_gt_5(i)

--- a/pyanalyze/test_annotated_types.py
+++ b/pyanalyze/test_annotated_types.py
@@ -1,0 +1,44 @@
+# static analysis: ignore
+from .implementation import assert_is_value
+from .test_name_check_visitor import TestNameCheckVisitorBase
+from .test_node_visitor import assert_passes, only_before
+from .tests import make_simple_sequence
+from .value import (
+    AnySource,
+    AnyValue,
+    GenericValue,
+    KnownValue,
+    SequenceValue,
+    TypedValue,
+)
+
+
+class TestGreaterLesser(TestNameCheckVisitorBase):
+    @assert_passes()
+    def test_gt(self):
+        from typing_extensions import Annotated
+        from typing import Any
+        from annotated_types import Gt, Ge
+
+        def takes_gt_5(x: Annotated[Any, Gt(5)]) -> None:
+            pass
+
+        def capybara(
+            i: int,
+            unnannotated,
+            gt_4: Annotated[int, Gt(4)],
+            gt_5: Annotated[int, Gt(5)],
+            gt_6: Annotated[int, Gt(6)],
+            ge_5: Annotated[int, Ge(5)],
+            ge_6: Annotated[int, Ge(6)],
+        ) -> None:
+            takes_gt_5(i)  # E: incompatible_argument
+            takes_gt_5(unnannotated)
+            takes_gt_5(gt_4)  # E: incompatible_argument
+            takes_gt_5(gt_5)
+            takes_gt_5(gt_6)
+            takes_gt_5(ge_5)  # E: incompatible_argument
+            takes_gt_5(ge_6)
+            takes_gt_5(5)  # E: incompatible_argument
+            takes_gt_5(6)
+            takes_gt_5("not an int")  # E: incompatible_argument

--- a/pyanalyze/test_stacked_scopes.py
+++ b/pyanalyze/test_stacked_scopes.py
@@ -1494,6 +1494,31 @@ class TestConstraints(TestNameCheckVisitorBase):
                 )
 
     @assert_passes()
+    def test_hasattr_annotated_unification(self):
+        from pyanalyze.value import HasAttrExtension
+
+        ext = HasAttrExtension(KnownValue("name"), AnyValue(AnySource.inference))
+
+        def capybara(x: int) -> None:
+            assert_is_value(x, TypedValue(int))
+            if hasattr(x, "name"):
+                assert_is_value(x, AnnotatedValue(TypedValue(int), [ext]))
+            assert_is_value(x, TypedValue(int) | AnnotatedValue(TypedValue(int), [ext]))
+
+    @assert_passes()
+    def test_gt_annotated_unification(self):
+        from pyanalyze.value import CustomCheckExtension
+        from pyanalyze.annotated_types import Gt
+
+        ext = CustomCheckExtension(Gt(5))
+
+        def capybara(x: int) -> None:
+            assert_is_value(x, TypedValue(int))
+            if x > 5:
+                assert_is_value(x, AnnotatedValue(TypedValue(int), [ext]))
+            assert_is_value(x, TypedValue(int) | AnnotatedValue(TypedValue(int), [ext]))
+
+    @assert_passes()
     def test_unconstrained_composite(self):
         class Foo(object):
             def has_images(self):

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,15 @@ if __name__ == "__main__":
             "codemod",
             "tomli>=1.1.0",
         ],
-        extras_require={"tests": ["pytest", "mypy_extensions", "attrs", "pydantic"]},
+        extras_require={
+            "tests": [
+                "pytest",
+                "mypy_extensions",
+                "attrs",
+                "pydantic",
+                "annotated-types",
+            ]
+        },
         # These are useful for unit tests of pyanalyze extensions
         # outside the package.
         package_data={"pyanalyze": package_data},


### PR DESCRIPTION
This adds support for checking `annotated_types` annotations against literals, as well as a few tricks to make them more usable:
- Allowing stronger annotations where a weaker one is requested; for example, allow `Annotated[int, Gt(6)]` where `Annotated[int, Gt(5)]` is requested.
- Inferring annotations in some cases (`if x > 5:` essentially adds the annotation `Gt(5)`).

Future work:
- We should also infer predicates for `if len(x) > 5:` but we currently don't.