### PR TITLE
Add test for illegal literal parameter

### DIFF
--- a/pyanalyze/test_annotations.py
+++ b/pyanalyze/test_annotations.py
@@ -127,7 +127,7 @@ class TestAnnotations(TestNameCheckVisitorBase):
     def test_literal(self):
         from typing_extensions import Literal
 
-        def capybara(x: Literal[True], y: Literal[True, False]) -> None:
+        def capybara(x: Literal[True], y: Literal[(True, False)]) -> None:
             assert_is_value(x, KnownValue(True))
             assert_is_value(y, MultiValuedValue([KnownValue(True), KnownValue(False)]))
 


### PR DESCRIPTION
According to [typing spec](https://github.com/JelleZijlstra/typing-spec/blob/main/spec/spec.rst#illegal-parameters-for-literal-at-type-check-time) tuple value inside a Literal type annotation is not allowed.