### PR TITLE
Fix possibly_undefined_name on use of the walrus operator

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix incorrect `possibly_undefined_name` error on certain uses of the
+  walrus operator (#749)
 - Fix narrowing on `isinstance` calls with arguments that are not
   instance of `typing`, such as unions and certain typing special forms (#747)
 - Detect invalid calls to `isinstance` (#747)

--- a/pyanalyze/stacked_scopes.py
+++ b/pyanalyze/stacked_scopes.py
@@ -342,7 +342,9 @@ class Constraint(AbstractConstraint):
         """
         inner_value = value.value if isinstance(value, AnnotatedValue) else value
         if inner_value is UNINITIALIZED_VALUE:
-            yield UNINITIALIZED_VALUE
+            # If a constraint applies to a value, it must have been initialized,
+            # or at least we must have already tried to read it and gotten a
+            # possibly_undefined_name error.
             return
         if self.constraint_type == ConstraintType.is_instance:
             if isinstance(inner_value, AnyValue):

--- a/pyanalyze/test_name_check_visitor.py
+++ b/pyanalyze/test_name_check_visitor.py
@@ -2057,6 +2057,8 @@ class TestWalrus(TestNameCheckVisitorBase):
         def capybara(cond):
             if cond and (x := 1):
                 assert_type(x, Literal[1])
+            else:
+                print(x)  # E: possibly_undefined_name
             print(x)  # E: possibly_undefined_name
 
     def test_if_exp(self):

--- a/pyanalyze/test_name_check_visitor.py
+++ b/pyanalyze/test_name_check_visitor.py
@@ -2050,6 +2050,15 @@ class TestWalrus(TestNameCheckVisitorBase):
             """
         )
 
+    @assert_passes()
+    def test_and_then_walrus(self):
+        from typing_extensions import Literal, assert_type
+
+        def capybara(cond):
+            if cond and (x := 1):
+                assert_type(x, Literal[1])
+            print(x)  # E: possibly_undefined_name
+
     def test_if_exp(self):
         self.assert_passes(
             """

--- a/pyanalyze/test_stacked_scopes.py
+++ b/pyanalyze/test_stacked_scopes.py
@@ -818,7 +818,7 @@ class TestLeavesScope(TestNameCheckVisitorBase):
             else:
                 pass
 
-            return x  # static analysis: ignore[possibly_undefined_name]
+            return x  # E: possibly_undefined_name
 
         def kerodon():
             # make sure we don't propagate the UNINITIALIZED_VALUE from
@@ -1704,6 +1704,17 @@ class TestConstraints(TestNameCheckVisitorBase):
                 assert_is_value(x, AnnotatedValue(TypedValue(str), [KnownValue(1)]))
             else:
                 assert_is_value(x, AnnotatedValue(KnownValue(None), [KnownValue(1)]))
+
+    @assert_passes()
+    def test_possibly_undefined(self):
+        from typing_extensions import Literal, assert_type
+
+        def capybara(cond):
+            if cond:
+                x = 1
+
+            if x:  # E: possibly_undefined_name
+                assert_type(x, Literal[1])
 
 
 class TestComposite(TestNameCheckVisitorBase):


### PR DESCRIPTION
A suspiciously simple fix but I think it's correct.

Fixes #597