### PR TITLE
Improve performance of constructing typeshed_client

### DIFF
--- a/pyanalyze/typeshed.py
+++ b/pyanalyze/typeshed.py
@@ -16,6 +16,7 @@ from collections.abc import Collection, MutableMapping
 from collections.abc import Set as AbstractSet
 from dataclasses import dataclass, field, replace
 from enum import EnumMeta
+from pathlib import Path
 from types import GeneratorType, MethodDescriptorType, ModuleType
 from typing import (
     Any,
@@ -184,7 +185,9 @@ class TypeshedFinder:
         verbose: bool = False,
     ) -> "TypeshedFinder":
         extra_paths = options.get_value_for(StubPath)
-        ctx = typeshed_client.get_search_context()
+        ctx = typeshed_client.get_search_context(
+            search_path=[Path(p) for p in sys.path]
+        )
         ctx = typeshed_client.get_search_context(
             search_path=[*ctx.search_path, *extra_paths]
         )


### PR DESCRIPTION
If no search_path is passed, typeshed-client uses a subprocess to find sys.path (because
it supports getting paths for another Python interpreter). Here we don't need that; just
pass sys.path directly.
