### PR TITLE
Enable ANSI color codes for windows cmd

### DIFF
--- a/pyanalyze/__main__.py
+++ b/pyanalyze/__main__.py
@@ -1,8 +1,9 @@
 import sys
 from os import system
-system("") # Enable ANSI color codes for Windows cmd using this strange workaround ( see https://github.com/python/cpython/issues/74261 )
-
 from pyanalyze.name_check_visitor import NameCheckVisitor
+
+# Enable ANSI color codes for Windows cmd using this strange workaround ( see https://github.com/python/cpython/issues/74261 )
+system("")
 
 
 def main() -> None:

--- a/pyanalyze/__main__.py
+++ b/pyanalyze/__main__.py
@@ -3,7 +3,8 @@ from os import system
 
 from pyanalyze.name_check_visitor import NameCheckVisitor
 
-# Enable ANSI color codes for Windows cmd using this strange workaround ( see https://github.com/python/cpython/issues/74261 )
+# Enable ANSI color codes for Windows cmd using this strange workaround
+# ( see https://github.com/python/cpython/issues/74261 )
 system("")
 
 

--- a/pyanalyze/__main__.py
+++ b/pyanalyze/__main__.py
@@ -1,5 +1,6 @@
 import sys
 from os import system
+
 from pyanalyze.name_check_visitor import NameCheckVisitor
 
 # Enable ANSI color codes for Windows cmd using this strange workaround ( see https://github.com/python/cpython/issues/74261 )

--- a/pyanalyze/__main__.py
+++ b/pyanalyze/__main__.py
@@ -1,5 +1,5 @@
-import sys
 import os
+import sys
 
 from pyanalyze.name_check_visitor import NameCheckVisitor
 

--- a/pyanalyze/__main__.py
+++ b/pyanalyze/__main__.py
@@ -1,4 +1,6 @@
 import sys
+from os import system
+system("") # Enable ANSI color codes for Windows cmd using this strange workaround ( see https://github.com/python/cpython/issues/74261 )
 
 from pyanalyze.name_check_visitor import NameCheckVisitor
 

--- a/pyanalyze/__main__.py
+++ b/pyanalyze/__main__.py
@@ -1,14 +1,14 @@
 import sys
-from os import system
+import os
 
 from pyanalyze.name_check_visitor import NameCheckVisitor
 
-# Enable ANSI color codes for Windows cmd using this strange workaround
-# ( see https://github.com/python/cpython/issues/74261 )
-system("")
-
 
 def main() -> None:
+    if os.name == "nt":
+        # Enable ANSI color codes for Windows cmd using this strange workaround
+        # ( see https://github.com/python/cpython/issues/74261 )
+        os.system("")
     sys.exit(NameCheckVisitor.main())
 
 


### PR DESCRIPTION
I still use windows cmd, and the color codes used by pyanalyze do not work on there, instead printing a bunch of codes like `←[37m    ←[39;49;00ms`, However, for [whatever reason](https://github.com/python/cpython/issues/74261) you can fix this simply by calling `os.system("")` once.

I am making this a pull request, even though I am not sure where to best put the code that fixes this, in case the placement of the code doesn't matter and the PR saves everyone some trouble.