### PR TITLE
Update PEP 728 support to work with new version of typing-extensions

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Update PEP 728 support to the latest version, using the `extra_items=`
+  class argument instead of an `__extra_items__` key in the dict. (#855)
 - Add support for Python 3.13 (#824)
 - Drop support for Python 3.8 (#820)
 - Flag invalid regexes in arguments to functions like

--- a/pyanalyze/annotations.py
+++ b/pyanalyze/annotations.py
@@ -423,9 +423,14 @@ def _type_from_runtime(
         readonly_keys = getattr(val, "__readonly_keys__", None)
         total = getattr(val, "__total__", True)
         extra_keys = None
+        # Deprecated
         if hasattr(val, "__extra_keys__"):
             extra_keys = _type_from_runtime(val.__extra_keys__, ctx, is_typeddict=True)
         if hasattr(val, "__closed__") and val.__closed__:
+            extra_keys = NO_RETURN_VALUE
+        elif hasattr(val, "__extra_items__") and not is_typing_name(
+            val.__extra_items__, "NoExtraItems"
+        ):
             extra_keys = _type_from_runtime(val.__extra_items__, ctx, is_typeddict=True)
         extra_readonly = False
         while isinstance(extra_keys, TypeQualifierValue):

--- a/pyanalyze/test_implementation.py
+++ b/pyanalyze/test_implementation.py
@@ -972,15 +972,13 @@ class TestDictDelitem(TestNameCheckVisitorBase):
             a: str
             b: NotRequired[int]
 
-        class ExtraItemsTD(TypedDict, closed=True):
+        class ExtraItemsTD(TypedDict, extra_items=int):
             a: str
             b: NotRequired[int]
-            __extra_items__: int
 
-        class ReadOnlyExtraItemsTD(TypedDict, closed=True):
+        class ReadOnlyExtraItemsTD(TypedDict, extra_items=ReadOnly[int]):
             a: str
             b: NotRequired[int]
-            __extra_items__: ReadOnly[int]
 
         def capybara(
             td: TD,


### PR DESCRIPTION
PEP 728 changed significantly since I first added support for it to pyanalyze
last year. We are about to release a new version of typing-extensions, and this
change makes pyanalyze work with this new typing-extensions release.
