### PR TITLE
Infer precise type for fn.asyncio

### DIFF
--- a/pyanalyze/arg_spec.py
+++ b/pyanalyze/arg_spec.py
@@ -147,7 +147,7 @@ def with_implementation(fn: object, implementation_fn: Impl) -> Iterator[None]:
             yield
 
 
-def is_dot_asynq_function(obj: Any) -> bool:
+def is_dot_asynq_function(obj: Any, native: bool = False) -> bool:
     """Returns whether obj is the .asynq member on an async function."""
     try:
         self_obj = obj.__self__
@@ -170,7 +170,11 @@ def is_dot_asynq_function(obj: Any) -> bool:
     if not is_async_fn:
         return False
 
-    return getattr(obj, "__name__", None) in ("async", "asynq")
+    if native:
+        attributes = ("asyncio",)
+    else:
+        attributes = ("async", "asynq")
+    return getattr(obj, "__name__", None) in attributes
 
 
 @dataclass
@@ -666,7 +670,7 @@ class ArgSpecCache:
             return None  # lost cause
 
         # Cythonized methods, e.g. fn.asynq
-        if is_dot_asynq_function(obj):
+        if is_dot_asynq_function(obj) or is_dot_asynq_function(obj, native=True):
             try:
                 return self._cached_get_argspec(
                     obj.__self__, impl, is_asynq, in_overload_resolution

--- a/pyanalyze/name_check_visitor.py
+++ b/pyanalyze/name_check_visitor.py
@@ -5618,9 +5618,10 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
         ) and callee_wrapped.secondary_attr_name in ("async", "asynq"):
             async_fn = callee_wrapped.get_method()
             return AsyncTaskIncompleteValue(_get_task_cls(async_fn), return_value)
-        if isinstance(
-            callee_wrapped, UnboundMethodValue
-        ) and callee_wrapped.secondary_attr_name == "asyncio":
+        if (
+            isinstance(callee_wrapped, UnboundMethodValue)
+            and callee_wrapped.secondary_attr_name == "asyncio"
+        ):
             return GenericValue(collections.abc.Awaitable, [return_value])
         elif isinstance(callee_wrapped, UnboundMethodValue) and asynq.is_pure_async_fn(
             callee_wrapped.get_method()

--- a/pyanalyze/name_check_visitor.py
+++ b/pyanalyze/name_check_visitor.py
@@ -5609,11 +5609,19 @@ class NameCheckVisitor(node_visitor.ReplacingNodeVisitor):
         ):
             async_fn = callee_wrapped.val.__self__
             return AsyncTaskIncompleteValue(_get_task_cls(async_fn), return_value)
-        elif isinstance(
+        if isinstance(callee_wrapped, KnownValue) and is_dot_asynq_function(
+            callee_wrapped.val, native=True
+        ):
+            return GenericValue(collections.abc.Awaitable, [return_value])
+        if isinstance(
             callee_wrapped, UnboundMethodValue
         ) and callee_wrapped.secondary_attr_name in ("async", "asynq"):
             async_fn = callee_wrapped.get_method()
             return AsyncTaskIncompleteValue(_get_task_cls(async_fn), return_value)
+        if isinstance(
+            callee_wrapped, UnboundMethodValue
+        ) and callee_wrapped.secondary_attr_name == "asyncio":
+            return GenericValue(collections.abc.Awaitable, [return_value])
         elif isinstance(callee_wrapped, UnboundMethodValue) and asynq.is_pure_async_fn(
             callee_wrapped.get_method()
         ):

--- a/pyanalyze/test_asynq.py
+++ b/pyanalyze/test_asynq.py
@@ -220,6 +220,18 @@ class TestReturn(TestNameCheckVisitorBase):
                 return 3
             yield capybara.asynq(False)
 
+    @assert_passes()
+    def test_asyncio_correct_args(self):
+        from asynq import asynq
+
+        @asynq()
+        def capybara(arg: str) -> int:
+            return 0
+
+        async def test() -> None:
+            x: int = await capybara.asyncio(42)  # E: incompatible_argument
+            y: str = await capybara.asyncio("no")  # E: incompatible_assignment
+
 
 class TestBindDecorator(TestNameCheckVisitorBase):
     @assert_passes()

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 asynq
 qcore>=0.5.1
 ast_decompiler>=0.4.0
-typeshed_client>=2.0.0
+typeshed_client==2.7.0
 typing_extensions>=4.12.2
 codemod
 myst-parser==4.0.0

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ if __name__ == "__main__":
             "asynq",
             "qcore>=0.5.1",
             "ast_decompiler>=0.4.0",
-            "typeshed_client>=2.1.0",
+            "typeshed_client==2.7.0",
             "typing_extensions>=4.12.2",
             "codemod",
             "tomli>=1.1.0",


### PR DESCRIPTION
This essentially mimics the `.asynq` support:
* The argument type handling is the same
* The return type handling is similar, but use `Awaitable` instead of `asynq.Future`